### PR TITLE
Add Docs italia views

### DIFF
--- a/readthedocs/core/views/__init__.py
+++ b/readthedocs/core/views/__init__.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import render, get_object_or_404, redirect
 from django.views.decorators.csrf import csrf_exempt
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, DetailView
 
 from readthedocs.builds.models import Build
 from readthedocs.builds.models import Version
@@ -41,6 +41,21 @@ class HomepageView(TemplateView):
         context = super(HomepageView, self).get_context_data(**kwargs)
         context['featured_list'] = Project.objects.filter(featured=True)
         context['projects_count'] = Project.objects.count()
+        return context
+
+
+class ProjectView(DetailView):
+
+    model = Project
+    context_object_name = 'project'
+    template_name = 'project.html'
+    queryset = Project.objects.all()
+
+    def get_context_data(self, **kwargs):
+        """Add children projects."""
+        context = super(ProjectView, self).get_context_data(**kwargs)
+        project = context['project']
+        context['project_list'] = project.related_projects.all()
         return context
 
 

--- a/readthedocs/docsitalia/models.py
+++ b/readthedocs/docsitalia/models.py
@@ -108,6 +108,7 @@ class Publisher(models.Model):
         )
 
     def get_absolute_url(self):
+        """Get absolute url for publisher"""
         return reverse('publisher_detail', args=[self.slug])
 
 
@@ -145,4 +146,5 @@ class PublisherProject(models.Model):
         return self.name
 
     def get_absolute_url(self):
-        return reverse('publisher_project_detail', args=[self.publisher.slug ,self.slug])
+        """get absolute url for publisher project"""
+        return reverse('publisher_project_detail', args=[self.publisher.slug, self.slug])

--- a/readthedocs/docsitalia/models.py
+++ b/readthedocs/docsitalia/models.py
@@ -9,6 +9,7 @@ from django.contrib.postgres.fields import JSONField
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils.text import slugify
+from django.core.urlresolvers import reverse
 
 from readthedocs.projects.models import Project
 from readthedocs.oauth.models import RemoteOrganization
@@ -106,6 +107,9 @@ class Publisher(models.Model):
             active=False
         )
 
+    def get_absolute_url(self):
+        return reverse('publisher_detail', args=[self.slug])
+
 
 @python_2_unicode_compatible
 class PublisherProject(models.Model):
@@ -139,3 +143,6 @@ class PublisherProject(models.Model):
 
     def __str__(self):
         return self.name
+
+    def get_absolute_url(self):
+        return reverse('publisher_project_detail', args=[self.publisher.slug ,self.slug])

--- a/readthedocs/docsitalia/urls.py
+++ b/readthedocs/docsitalia/urls.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from django.conf.urls import url
 
-from .views.core_views import PublisherIndex, DocsItaliaHomePage, PublisherProjectIndex
 from .views.core_views import DocsItaliaHomePage, PublisherIndex, PublisherProjectIndex
 
 

--- a/readthedocs/docsitalia/urls.py
+++ b/readthedocs/docsitalia/urls.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+from django.conf.urls import url
+
+from .views.core_views import PublisherIndex, DocsItaliaHomePage, PublisherProjectIndex
+from .views.core_views import DocsItaliaHomePage, PublisherIndex, PublisherProjectIndex
+
+
+urlpatterns = [
+    url(
+        r'^$',
+        DocsItaliaHomePage.as_view(),
+        name='docsitalia_homepage'
+    ),
+    url(
+        r'^(?P<slug>[-\w]+)$',
+        PublisherIndex.as_view(),
+        name='publisher_detail'
+    ),
+    url(
+        r'^(?P<publisherslug>[-\w]+)/(?P<slug>[-\w]+)$',
+        PublisherProjectIndex.as_view(),
+        name='publisher_project_detail'
+    ),
+]

--- a/readthedocs/docsitalia/views.py
+++ b/readthedocs/docsitalia/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/readthedocs/docsitalia/views/__init__.py
+++ b/readthedocs/docsitalia/views/__init__.py
@@ -1,0 +1,1 @@
+"""Docs Italia Views"""

--- a/readthedocs/docsitalia/views/core_views.py
+++ b/readthedocs/docsitalia/views/core_views.py
@@ -9,7 +9,7 @@ from readthedocs.docsitalia.models import PublisherProject, Publisher
 from readthedocs.projects.models import Project
 
 
-class DocsItaliaHomePage(ListView):
+class DocsItaliaHomePage(ListView): #  pylint: disable=too-many-ancestors
 
     """Docs italia Home Page"""
 
@@ -19,19 +19,19 @@ class DocsItaliaHomePage(ListView):
     def get_queryset(self):
         """get queryset"""
         actives = PublisherProject.objects.filter(active=True)
-        return Project.objects.filter( # this will eventually become most viewed this month
-            publisherproject__in=actives).order_by('-modified_date', '-pub_date'
+        return Project.objects.filter(publisherproject__in=actives).order_by(
+            '-modified_date', '-pub_date'
         )[:24]
 
 
-class PublisherIndex(DetailView):
+class PublisherIndex(DetailView): #  pylint: disable=too-many-ancestors
 
     """Detail view of :py:class:`Publisher` instances."""
 
     model = Publisher
 
 
-class PublisherProjectIndex(DetailView):
+class PublisherProjectIndex(DetailView): #  pylint: disable=too-many-ancestors
 
     """Detail view of :py:class:`PublisherProject` instances."""
 

--- a/readthedocs/docsitalia/views/core_views.py
+++ b/readthedocs/docsitalia/views/core_views.py
@@ -4,9 +4,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from django.shortcuts import render
-from readthedocs.docsitalia.models import PublisherProject, Publisher
 from django.views.generic import DetailView, ListView
+from readthedocs.docsitalia.models import PublisherProject, Publisher
 from readthedocs.projects.models import Project
 
 
@@ -17,15 +16,12 @@ class DocsItaliaHomePage(ListView):
     model = Project
     template_name = 'docsitalia/docsitalia_homepage.html'
 
-    def get_context_data(self, **kwargs):
-        context = super(DocsItaliaHomePage, self).get_context_data(**kwargs)
-        return context
-
     def get_queryset(self):
+        """get queryset"""
         actives = PublisherProject.objects.filter(active=True)
         return Project.objects.filter( # this will eventually become most viewed this month
             publisherproject__in=actives).order_by('-modified_date', '-pub_date'
-        )[:10]
+        )[:24]
 
 
 class PublisherIndex(DetailView):
@@ -34,17 +30,9 @@ class PublisherIndex(DetailView):
 
     model = Publisher
 
-    def get_context_data(self, **kwargs):
-        context = super(PublisherIndex, self).get_context_data(**kwargs)
-        return context
-
 
 class PublisherProjectIndex(DetailView):
 
     """Detail view of :py:class:`PublisherProject` instances."""
 
     model = PublisherProject
-
-    def get_context_data(self, **kwargs):
-        context = super(PublisherProjectIndex, self).get_context_data(**kwargs)
-        return context

--- a/readthedocs/docsitalia/views/core_views.py
+++ b/readthedocs/docsitalia/views/core_views.py
@@ -9,7 +9,7 @@ from readthedocs.docsitalia.models import PublisherProject, Publisher
 from readthedocs.projects.models import Project
 
 
-class DocsItaliaHomePage(ListView): #  pylint: disable=too-many-ancestors
+class DocsItaliaHomePage(ListView):  # pylint: disable=too-many-ancestors
 
     """Docs italia Home Page"""
 
@@ -24,14 +24,14 @@ class DocsItaliaHomePage(ListView): #  pylint: disable=too-many-ancestors
         )[:24]
 
 
-class PublisherIndex(DetailView): #  pylint: disable=too-many-ancestors
+class PublisherIndex(DetailView):  # pylint: disable=too-many-ancestors
 
     """Detail view of :py:class:`Publisher` instances."""
 
     model = Publisher
 
 
-class PublisherProjectIndex(DetailView): #  pylint: disable=too-many-ancestors
+class PublisherProjectIndex(DetailView):  # pylint: disable=too-many-ancestors
 
     """Detail view of :py:class:`PublisherProject` instances."""
 

--- a/readthedocs/docsitalia/views/core_views.py
+++ b/readthedocs/docsitalia/views/core_views.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""Public project views."""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from django.shortcuts import render
+from readthedocs.docsitalia.models import PublisherProject, Publisher
+from django.views.generic import DetailView, ListView
+from readthedocs.projects.models import Project
+
+
+class DocsItaliaHomePage(ListView):
+
+    """Docs italia Home Page"""
+
+    model = Project
+    template_name = 'docsitalia/docsitalia_homepage.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(DocsItaliaHomePage, self).get_context_data(**kwargs)
+        return context
+
+    def get_queryset(self):
+        actives = PublisherProject.objects.filter(active=True)
+        return Project.objects.filter( # this will eventually become most viewed this month
+            publisherproject__in=actives).order_by('-modified_date', '-pub_date'
+        )[:10]
+
+
+class PublisherIndex(DetailView):
+
+    """Detail view of :py:class:`Publisher` instances."""
+
+    model = Publisher
+
+    def get_context_data(self, **kwargs):
+        context = super(PublisherIndex, self).get_context_data(**kwargs)
+        return context
+
+
+class PublisherProjectIndex(DetailView):
+
+    """Detail view of :py:class:`PublisherProject` instances."""
+
+    model = PublisherProject
+
+    def get_context_data(self, **kwargs):
+        context = super(PublisherProjectIndex, self).get_context_data(**kwargs)
+        return context

--- a/readthedocs/rtd_tests/tests/test_search.py
+++ b/readthedocs/rtd_tests/tests/test_search.py
@@ -58,7 +58,7 @@ class TestSearch(TestCase):
         self.client.login(username='eric', password='test')
         r = self.client.get(
             reverse('search'),
-            {'q': 'pip', 'type': 'project', 'project': None}
+            {'q': 'pip', 'type': 'project'}
         )
         self.assertEqual(r.status_code, 200)
         response = perform_request_mock.call_args_list[0][0][3]

--- a/readthedocs/search/lib.py
+++ b/readthedocs/search/lib.py
@@ -155,31 +155,7 @@ def search_file(request, query, project_slug=None, version_slug=LATEST, taxonomy
 
         if project_slug:
             try:
-<<<<<<< HEAD
-                project = (Project.objects
-                           .api(request.user)
-                           .get(slug=project_slug))
-                project_slugs = [project.slug]
-                # We need to use the obtuse syntax here because the manager
-                # doesn't pass along to ProjectRelationships
-                project_slugs.extend(s.slug for s
-                                     in Project.objects.public(
-                                         request.user).filter(
-                                         superprojects__parent__slug=project.slug))
-                final_filter.append({"terms": {"project": project_slugs}})
-
-                # Add routing to optimize search by hitting the right shard.
-                # This purposely doesn't apply routing if the project has more
-                # than one parent project.
-                if project.superprojects.exists():
-                    if project.superprojects.count() == 1:
-                        kwargs['routing'] = (project.superprojects.first()
-                                             .parent.slug)
-                else:
-                    kwargs['routing'] = project_slug
-=======
                 project_filter, routing = search_project_filter(request, project_slug)
->>>>>>> bd30fd061ad738523f2f1f3d7b03c448a9c4b067
             except Project.DoesNotExist:
                 return None
 

--- a/readthedocs/search/lib.py
+++ b/readthedocs/search/lib.py
@@ -14,6 +14,31 @@ from readthedocs.search.signals import (before_project_search,
                                         before_section_search)
 
 
+def search_project_filter(request, project_slug):
+    project = (Project.objects
+               .api(request.user)
+               .get(slug=project_slug))
+    project_slugs = [project.slug]
+    # We need to use the obtuse syntax here because the manager
+    # doesn't pass along to ProjectRelationships
+    project_slugs.extend(s.slug for s
+                         in Project.objects.public(
+                             request.user).filter(
+                             superprojects__parent__slug=project.slug))
+    project_filter = {"terms": {"project": project_slugs}}
+
+    # Add routing to optimize search by hitting the right shard.
+    # This purposely doesn't apply routing if the project has more
+    # than one parent project.
+    if project.superprojects.exists():
+        if project.superprojects.count() == 1:
+            routing = (project.superprojects.first()
+                       .parent.slug)
+    else:
+        routing = project_slug
+    return project_filter, routing
+
+
 def search_project(request, query, language=None):
     """Search index for projects matching query."""
     body = {
@@ -116,29 +141,12 @@ def search_file(request, query, project_slug=None, version_slug=LATEST, taxonomy
 
         if project_slug:
             try:
-                project = (Project.objects
-                           .api(request.user)
-                           .get(slug=project_slug))
-                project_slugs = [project.slug]
-                # We need to use the obtuse syntax here because the manager
-                # doesn't pass along to ProjectRelationships
-                project_slugs.extend(s.slug for s
-                                     in Project.objects.public(
-                                         request.user).filter(
-                                         superprojects__parent__slug=project.slug))
-                final_filter['and'].append({"terms": {"project": project_slugs}})
-
-                # Add routing to optimize search by hitting the right shard.
-                # This purposely doesn't apply routing if the project has more
-                # than one parent project.
-                if project.superprojects.exists():
-                    if project.superprojects.count() == 1:
-                        kwargs['routing'] = (project.superprojects.first()
-                                             .parent.slug)
-                else:
-                    kwargs['routing'] = project_slug
+                project_filter, routing = search_project_filter(request, project_slug)
             except Project.DoesNotExist:
                 return None
+
+            final_filter['and'].append(project_filter)
+            kwargs['routing'] = routing
 
         if version_slug:
             final_filter['and'].append({'term': {'version': version_slug}})

--- a/readthedocs/search/views.py
+++ b/readthedocs/search/views.py
@@ -46,7 +46,8 @@ def elastic_search(request):
     if user_input.query:
         if user_input.type == 'project':
             results = search_lib.search_project(
-                request, user_input.query, language=user_input.language)
+                request, user_input.query, language=user_input.language,
+                project_slug=user_input.project)
         elif user_input.type == 'file':
             results = search_lib.search_file(
                 request, user_input.query, project_slug=user_input.project,

--- a/readthedocs/templates/core/widesearchbar.html
+++ b/readthedocs/templates/core/widesearchbar.html
@@ -10,6 +10,7 @@
             <form action="{% url "search" %}" method="GET">
               <div class="text-input-wrapper">
                 <input type="text" name="q" value="{{ term }}" id="id_site_search" placeholder="{% trans 'Search Read the Docs' %}">
+                <input type="hidden" name="project" value="{{ project_slug }}">
               </div>
               <div class="submit-input-wrapper">
                 {% comment %} Translators: This is about starting a search {% endcomment %}

--- a/readthedocs/templates/docsitalia/docsitalia_homepage.html
+++ b/readthedocs/templates/docsitalia/docsitalia_homepage.html
@@ -1,0 +1,34 @@
+{% extends "projects/base_project.html" %}
+{% load i18n %}
+
+{% block content %}
+{% comment %}
+    Home page di docs italia, al momento contiene la lista dei documenti (Project di RTD) più recenti
+{% endcomment %}
+<div>
+    {% for project in object_list %}
+        <div class="project">
+            {% with project.publisherproject_set.all.first as publisher %}
+                <a href="{{ publisher.get_absolute_url }}">{{ publisher }}</a>
+            {% endwith %}
+            {{ project }}
+            {{ project.version }}
+            <a class="" href="{{ project.get_absolute_url }}">{{ project }}</a>
+            {{ project.description|safe }}
+        </div>
+        <hr>
+    {% endfor %}
+</div>
+<div>
+    <h1>Cos'è Docs Italia?</h1>
+    <p>
+    Docs Italia è un servizio a disposizione delle Pubbliche Amministrazioni per pubblicare documenti tecnici e amministrativi, e offre ai cittadini la possibilità di leggere e commentare documenti pubblici ed essere informati sull’andamento dei progetti. Su Docs Italia trovi:
+    </p>
+    <ul>
+        <li>documentazione tecnica relativa ai progetti pubblici</li>
+        <li>Per esempio, su Docs Italia è possibile accedere alla documentazione relativa al progetto per costruire l’Anagrafe nazionale della popolazione residente in Italia</li>
+        <li>documenti amministrativi, circolari, linee guida, regole tecniche, direttive</li>
+        <li>Per esempio, su Docs Italia è disponibile il Codice dell’Amministrazione Digitale, la legge che definisce il ruolo del digitale nella Pubblica Amministrazione</li>
+    </ul>
+</div>
+{% endblock %}

--- a/readthedocs/templates/docsitalia/docsitalia_homepage.html
+++ b/readthedocs/templates/docsitalia/docsitalia_homepage.html
@@ -20,6 +20,9 @@
     {% endfor %}
 </div>
 <div>
+    {% include "core/widesearchbar.html" %}
+</div>
+<div>
     <h1>Cos'è Docs Italia?</h1>
     <p>
     Docs Italia è un servizio a disposizione delle Pubbliche Amministrazioni per pubblicare documenti tecnici e amministrativi, e offre ai cittadini la possibilità di leggere e commentare documenti pubblici ed essere informati sull’andamento dei progetti. Su Docs Italia trovi:

--- a/readthedocs/templates/docsitalia/publisher_detail.html
+++ b/readthedocs/templates/docsitalia/publisher_detail.html
@@ -1,0 +1,63 @@
+{% extends "projects/base_project.html" %}
+{% load i18n %}
+
+{% block content %}
+{% comment %}
+Pagina di dettaglio del publisher con la lista
+dei publisher projects
+{% endcomment %}
+    <h2>{{ object }} </h2>
+    <button class="js-open-publisher-search">Search</button>
+    {% for pb in object.publisherproject_set.all %}
+        <div>
+            <a href="{{ pb.get_absolute_url }}">{{ pb }}</a>
+        </div>
+    {% endfor %}
+    <div class="publisher-metadata">
+        {% if object.metadata %}
+            {{ object.metadata.name }}
+            <a href="{{ object.metadata.website }}">{{ object.metadata.website }}</a>
+            {{ object.metadata.description }}
+            <img src="{{ object.metadata.assets.logo }}" />
+        {% endif %}
+    </div>
+    <div class="publisher-projects-metadata">
+        {% if object.projects_metada %}
+            {{ object.projects_metadata.title }}
+            {{ object.projects_metadata.description }}
+            {{ object.projects_metadata.website }}
+        {% endif %}
+    </div>
+    <div class="publisher-search" style="display: none">
+    {% comment %}
+    Questo è il popup di ricerca
+    ancora da definire
+    {% endcomment %}
+        <a class="js-publisher-search-close">close</a>
+        {% include "core/widesearchbar.html" %}
+        <strong>Ricerche frequenti</strong>
+        <ul>
+            <li>
+                <a>Tag 1</a>
+            </li>
+            <li>
+                <a>Tag 2</a>
+            </li>
+            <li>
+                <a>Progetto Spid</a>
+            </li>
+        </ul>
+    </div>
+{% endblock %}
+{% block extra_scripts %}
+  <script type="text/javascript">
+    $(document).ready(function() {
+        $('.js-publisher-search-close').on('click', function(){
+            $('.publisher-search').hide();
+        });
+        $('.js-open-publisher-search').on('click', function(){
+            $('.publisher-search').show();
+        });
+    });
+  </script>
+{% endblock %}

--- a/readthedocs/templates/docsitalia/publisherproject_detail.html
+++ b/readthedocs/templates/docsitalia/publisherproject_detail.html
@@ -1,0 +1,26 @@
+{% extends "projects/base_project.html" %}
+{% load i18n %}
+
+{% block content %}
+{% comment %}
+Questa è la pagina di dettaglio del publisher
+project con la lista dei progetti (documenti)
+associati
+{% endcomment %}
+<h2>{{ object }}</h2>
+{% trans 'Available documents' %}
+<div>
+    <div>
+        {% for project in object.projects.all %}
+            <div>
+                {{ object }}
+                {{ project }}
+                {{ project.version }}
+                <a class="" href="{{ project.get_absolute_url }}">{{ project }}</a>
+                {{ project.description|safe }}
+            </div>
+            <hr>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -112,7 +112,7 @@
 
   <!-- Search -->
   <section>
-    {% include "core/widesearchbar.html" %}
+    {% include "core/widesearchbar.html" with project_slug="" %}
   </section>
 
   {% if featured_list %}

--- a/readthedocs/templates/project.html
+++ b/readthedocs/templates/project.html
@@ -50,7 +50,7 @@
 
   <!-- Search -->
   <section>
-    {% include "core/widesearchbar.html" %}
+    {% include "core/widesearchbar.html" with project_slug=project.slug %}
   </section>
 
   {% if project_list %}

--- a/readthedocs/templates/project.html
+++ b/readthedocs/templates/project.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% load humanize %}
+{% load pagination_tags %}
+
+{% block extra_metas %}
+  <meta name="description" content="{% trans "Read the Docs simplifies technical documentation by automating building, versioning, and hosting for you. Build up-to-date documentation for the web, print, and offline use on every version control push automatically." %}">
+{% endblock extra_metas %}
+
+{% block title %}{% trans "Home" %}{% endblock %}
+
+{% block body_class %}home {% if not request.user.is_authenticated %}splash{% endif %}{% endblock %}
+
+{% block nav-browse %}class="active"{% endblock %}
+
+{% block header-wrapper %}
+  {% if request.user.is_authenticated %}
+    {% include "core/header.html" %}
+  {% else %}
+    {% include "core/home-header.html" %}
+  {% endif %}
+{% endblock %}
+
+{% block extra_scripts %}
+        <script>
+    $(document).ready(function() {
+            // Show action on hover
+            $(".module-item-menu").hover(
+              function () {
+                $(".hidden-child", this).show();
+              }, function () {
+                $(".hidden-child", this).hide();
+              }
+            );
+    });
+        </script>
+{% endblock %}
+
+
+{% block content %}
+
+  <!-- Lead -->
+  <section>
+    <h2>{{ project.name }}</h2>
+    <p class="lead">
+    {{ project.description }}
+    </p>
+  </section>
+
+  <!-- Search -->
+  <section>
+    {% include "core/widesearchbar.html" %}
+  </section>
+
+  {% if project_list %}
+    <!-- BEGIN projects list -->
+    <section>
+      <h3>{% trans "Projects" %}</h3>
+      <div class="module-list">
+        <div class="module-list-wrapper">
+          <ul style="margin-bottom: 0">
+            {% include "core/project_list.html" %}
+          </ul>
+        </div>
+      </div>
+    </section>
+    <!-- END projects list -->
+  {% endif %}
+{% endblock %}

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -14,9 +14,10 @@ from tastypie.api import Api
 from readthedocs.api.base import (ProjectResource, UserResource,
                                   VersionResource, FileResource)
 from readthedocs.core.urls import docs_urls, core_urls, deprecated_urls
-from readthedocs.core.views import (HomepageView, SupportView,
+from readthedocs.core.views import (HomepageView, SupportView, ProjectView,
                                     server_error_404, server_error_500)
 from readthedocs.search import views as search_views
+from readthedocs.constants import pattern_opts
 
 
 v1_api = Api(api_name='v1')
@@ -32,6 +33,8 @@ handler500 = server_error_500
 
 basic_urls = [
     url(r'^$', HomepageView.as_view(), name='homepage'),
+    url(r'^project/(?P<slug>{project_slug})/$'.format(**pattern_opts),
+        ProjectView.as_view(), name='project_home_detail'),
     url(r'^support/', SupportView.as_view(), name='support'),
     url(r'^security/', TemplateView.as_view(template_name='security.html')),
     url(r'^.well-known/security.txt',

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -39,6 +39,7 @@ basic_urls = [
 ]
 
 rtd_urls = [
+    url(r'^docsitalia/', include('readthedocs.docsitalia.urls')), # to be moved
     url(r'^bookmarks/', include('readthedocs.bookmarks.urls')),
     url(r'^search/$', search_views.elastic_search, name='search'),
     url(r'^dashboard/', include('readthedocs.projects.urls.private')),


### PR DESCRIPTION
Add docs italia views:
* Home page
* Publisher View
* Publisher Project View

Prima di iniziare è importante lanciare le migrazioni.

python manage.py migrate

Fatto questo conviene caricare delle fixture se non si hanno contenuti in locale.

Lanciare il comando python manage.py loaddata

python manage.py loaddata readthedocs/projects/fixtures/test_data.json

python manage.py loaddata readthedocs/core/fixtures/eric.json

Conviene anche creare qualche contenuto per i modelli publisher e publisher project 
a questa url:

/admin/docsitalia/ 

a questo punto alla url /docsitalia dovreste vedere i publisher creati.

Ci sono tre views

La home page di docs italia:
---------------
Contiene momentaneamente gli ultimi 10 projects

Publisher detail
----------------
Questa va stilata :) E' la pagina di dettaglio del publisher e contiene
la lista dei publisher projects

*template:* /templates/docsitalia/publisher_detail.html

Publisher project detail
------------------------
Questa è la pagina di dettaglio del publisher project e contiene
la lista dei projects (i nostri documenti)
*template:* /templates/docsitalia/publisherproject_detail.html
