### PR TITLE
Add docs italia views

### DIFF
--- a/readthedocs/docsitalia/models.py
+++ b/readthedocs/docsitalia/models.py
@@ -9,6 +9,7 @@ from django.contrib.postgres.fields import JSONField
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils.text import slugify
+from django.core.urlresolvers import reverse
 
 from readthedocs.projects.models import Project
 from readthedocs.oauth.models import RemoteOrganization
@@ -106,6 +107,10 @@ class Publisher(models.Model):
             active=False
         )
 
+    def get_absolute_url(self):
+        """Get absolute url for publisher"""
+        return reverse('publisher_detail', args=[self.slug])
+
 
 @python_2_unicode_compatible
 class PublisherProject(models.Model):
@@ -139,3 +144,7 @@ class PublisherProject(models.Model):
 
     def __str__(self):
         return self.name
+
+    def get_absolute_url(self):
+        """get absolute url for publisher project"""
+        return reverse('publisher_project_detail', args=[self.publisher.slug, self.slug])

--- a/readthedocs/docsitalia/urls.py
+++ b/readthedocs/docsitalia/urls.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import
+from django.conf.urls import url
+
+from .views.core_views import DocsItaliaHomePage, PublisherIndex, PublisherProjectIndex
+
+
+urlpatterns = [
+    url(
+        r'^$',
+        DocsItaliaHomePage.as_view(),
+        name='docsitalia_homepage'
+    ),
+    url(
+        r'^(?P<slug>[-\w]+)/$',
+        PublisherIndex.as_view(),
+        name='publisher_detail'
+    ),
+    url(
+        r'^(?P<publisherslug>[-\w]+)/(?P<slug>[-\w]+)/$',
+        PublisherProjectIndex.as_view(),
+        name='publisher_project_detail'
+    ),
+]

--- a/readthedocs/docsitalia/views.py
+++ b/readthedocs/docsitalia/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/readthedocs/docsitalia/views/__init__.py
+++ b/readthedocs/docsitalia/views/__init__.py
@@ -1,0 +1,1 @@
+"""Docs Italia Views"""

--- a/readthedocs/docsitalia/views/core_views.py
+++ b/readthedocs/docsitalia/views/core_views.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""Public project views."""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from django.views.generic import DetailView, ListView
+from readthedocs.docsitalia.models import PublisherProject, Publisher
+from readthedocs.projects.models import Project
+
+
+class DocsItaliaHomePage(ListView):  # pylint: disable=too-many-ancestors
+
+    """Docs italia Home Page"""
+
+    model = Project
+    template_name = 'docsitalia/docsitalia_homepage.html'
+
+    def get_queryset(self):
+        """get queryset"""
+        actives = PublisherProject.objects.filter(active=True)
+        return Project.objects.filter(publisherproject__in=actives).order_by(
+            '-modified_date', '-pub_date'
+        )[:24]
+
+
+class PublisherIndex(DetailView):  # pylint: disable=too-many-ancestors
+
+    """Detail view of :py:class:`Publisher` instances."""
+
+    model = Publisher
+
+
+class PublisherProjectIndex(DetailView):  # pylint: disable=too-many-ancestors
+
+    """Detail view of :py:class:`PublisherProject` instances."""
+
+    model = PublisherProject

--- a/readthedocs/templates/docsitalia/docsitalia_homepage.html
+++ b/readthedocs/templates/docsitalia/docsitalia_homepage.html
@@ -1,0 +1,37 @@
+{% extends "projects/base_project.html" %}
+{% load i18n %}
+
+{% block content %}
+{% comment %}
+    Home page di docs italia, al momento contiene la lista dei documenti (Project di RTD) più recenti
+{% endcomment %}
+<div>
+    {% for project in object_list %}
+        <div class="project">
+            {% with project.publisherproject_set.all.first as publisher %}
+                <a href="{{ publisher.get_absolute_url }}">{{ publisher }}</a>
+            {% endwith %}
+            {{ project }}
+            {{ project.version }}
+            <a class="" href="{{ project.get_absolute_url }}">{{ project }}</a>
+            {{ project.description|safe }}
+        </div>
+        <hr>
+    {% endfor %}
+</div>
+<div>
+    {% include "core/widesearchbar.html" %}
+</div>
+<div>
+    <h1>Cos'è Docs Italia?</h1>
+    <p>
+    Docs Italia è un servizio a disposizione delle Pubbliche Amministrazioni per pubblicare documenti tecnici e amministrativi, e offre ai cittadini la possibilità di leggere e commentare documenti pubblici ed essere informati sull’andamento dei progetti. Su Docs Italia trovi:
+    </p>
+    <ul>
+        <li>documentazione tecnica relativa ai progetti pubblici</li>
+        <li>Per esempio, su Docs Italia è possibile accedere alla documentazione relativa al progetto per costruire l’Anagrafe nazionale della popolazione residente in Italia</li>
+        <li>documenti amministrativi, circolari, linee guida, regole tecniche, direttive</li>
+        <li>Per esempio, su Docs Italia è disponibile il Codice dell’Amministrazione Digitale, la legge che definisce il ruolo del digitale nella Pubblica Amministrazione</li>
+    </ul>
+</div>
+{% endblock %}

--- a/readthedocs/templates/docsitalia/publisher_detail.html
+++ b/readthedocs/templates/docsitalia/publisher_detail.html
@@ -1,0 +1,63 @@
+{% extends "projects/base_project.html" %}
+{% load i18n %}
+
+{% block content %}
+{% comment %}
+Pagina di dettaglio del publisher con la lista
+dei publisher projects
+{% endcomment %}
+    <h2>{{ object }} </h2>
+    <button class="js-open-publisher-search">Search</button>
+    {% for pb in object.publisherproject_set.all %}
+        <div>
+            <a href="{{ pb.get_absolute_url }}">{{ pb }}</a>
+        </div>
+    {% endfor %}
+    <div class="publisher-metadata">
+        {% if object.metadata %}
+            {{ object.metadata.name }}
+            <a href="{{ object.metadata.website }}">{{ object.metadata.website }}</a>
+            {{ object.metadata.description }}
+            <img src="{{ object.metadata.assets.logo }}" />
+        {% endif %}
+    </div>
+    <div class="publisher-projects-metadata">
+        {% if object.projects_metada %}
+            {{ object.projects_metadata.title }}
+            {{ object.projects_metadata.description }}
+            {{ object.projects_metadata.website }}
+        {% endif %}
+    </div>
+    <div class="publisher-search" style="display: none">
+    {% comment %}
+    Questo è il popup di ricerca
+    ancora da definire
+    {% endcomment %}
+        <a class="js-publisher-search-close">close</a>
+        {% include "core/widesearchbar.html" %}
+        <strong>Ricerche frequenti</strong>
+        <ul>
+            <li>
+                <a>Tag 1</a>
+            </li>
+            <li>
+                <a>Tag 2</a>
+            </li>
+            <li>
+                <a>Progetto Spid</a>
+            </li>
+        </ul>
+    </div>
+{% endblock %}
+{% block extra_scripts %}
+  <script type="text/javascript">
+    $(document).ready(function() {
+        $('.js-publisher-search-close').on('click', function(){
+            $('.publisher-search').hide();
+        });
+        $('.js-open-publisher-search').on('click', function(){
+            $('.publisher-search').show();
+        });
+    });
+  </script>
+{% endblock %}

--- a/readthedocs/templates/docsitalia/publisherproject_detail.html
+++ b/readthedocs/templates/docsitalia/publisherproject_detail.html
@@ -1,0 +1,26 @@
+{% extends "projects/base_project.html" %}
+{% load i18n %}
+
+{% block content %}
+{% comment %}
+Questa è la pagina di dettaglio del publisher
+project con la lista dei progetti (documenti)
+associati
+{% endcomment %}
+<h2>{{ object }}</h2>
+{% trans 'Available documents' %}
+<div>
+    <div>
+        {% for project in object.projects.all %}
+            <div>
+                {{ object }}
+                {{ project }}
+                {{ project.version }}
+                <a class="" href="{{ project.get_absolute_url }}">{{ project }}</a>
+                {{ project.description|safe }}
+            </div>
+            <hr>
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -39,6 +39,7 @@ basic_urls = [
 ]
 
 rtd_urls = [
+    url(r'^docsitalia/', include('readthedocs.docsitalia.urls')), # to be moved
     url(r'^bookmarks/', include('readthedocs.bookmarks.urls')),
     url(r'^search/$', search_views.elastic_search, name='search'),
     url(r'^dashboard/', include('readthedocs.projects.urls.private')),


### PR DESCRIPTION
Add docs italia views:

Home page
Publisher View
Publisher Project View
Prima di iniziare è importante lanciare le migrazioni.

python manage.py migrate

Fatto questo conviene caricare delle fixture se non si hanno contenuti in locale.

Lanciare il comando python manage.py loaddata

python manage.py loaddata readthedocs/projects/fixtures/test_data.json

python manage.py loaddata readthedocs/core/fixtures/eric.json

Conviene anche creare qualche contenuto per i modelli publisher e publisher project
a questa url:

/admin/docsitalia/

a questo punto alla url /docsitalia dovreste vedere la lista degli ultimi doc inseriti.


Ci sono tre views:

La home page di docs italia:
Contiene momentaneamente gli ultimi 10 projects

Publisher detail
Questa va stilata :) E' la pagina di dettaglio del publisher e contiene
la lista dei publisher projects

template: /templates/docsitalia/publisher_detail.html

Publisher project detail
Questa è la pagina di dettaglio del publisher project e contiene
la lista dei projects (i nostri documenti)
template: /templates/docsitalia/publisherproject_detail.html