### PR TITLE
docsitalia: prefix integrations urls

### DIFF
--- a/readthedocs/docsitalia/urls.py
+++ b/readthedocs/docsitalia/urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.conf.urls import url
+from django.conf.urls import include, url
 
 from readthedocs.constants import pattern_opts
 
@@ -8,7 +8,7 @@ from .views.core_views import DocsItaliaHomePage, PublisherIndex, PublisherProje
 from .views import integrations
 
 
-integrations_urls = [
+docsitalia_urls = [
     url(r'webhook/github/(?P<publisher_slug>{project_slug})/$'.format(**pattern_opts),
         integrations.MetadataGitHubWebhookView.as_view(),
         name='metadata_webhook_github'),
@@ -35,4 +35,5 @@ urlpatterns = [
         PublisherProjectIndex.as_view(),
         name='publisher_project_detail'
     ),
-] + integrations_urls
+    url(r'^docsitalia/', include(docsitalia_urls)),
+]


### PR DESCRIPTION
After docsitalia urls got mounted in / we need to be careful to
not override upstream urls, so prefix integrations urls under
docsitalia/.