### PR TITLE
projects: workaround slumber api not decoding json

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -475,6 +475,9 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
     def get_project(project_pk):
         """Get project from API."""
         project_data = api_v2.project(project_pk).get()
+        # workaround for getting bytes instead of deserialized json
+        if isinstance(project_data, bytes):
+            project_data = json.loads(project_data.decode())
         return APIProject(**project_data)
 
     @staticmethod


### PR DESCRIPTION
For some reasons the call to the project data does not return
a dict but plain bytes. If that's the case deserialize ourselves
the response.