### PR TITLE
Fix slumber returning bytes instead of deserialized data

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -475,9 +475,6 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
     def get_project(project_pk):
         """Get project from API."""
         project_data = api_v2.project(project_pk).get()
-        # workaround for getting bytes instead of deserialized json
-        if isinstance(project_data, bytes):
-            project_data = json.loads(project_data.decode())
         return APIProject(**project_data)
 
     @staticmethod

--- a/readthedocs/restapi/client.py
+++ b/readthedocs/restapi/client.py
@@ -7,7 +7,6 @@ from slumber import API, serialize
 import requests
 from django.conf import settings
 from rest_framework.renderers import JSONRenderer
-from rest_framework.parsers import JSONParser
 
 
 log = logging.getLogger(__name__)
@@ -20,12 +19,9 @@ PASS = getattr(settings, 'SLUMBER_PASSWORD', None)
 
 class DrfJsonSerializer(serialize.JsonSerializer):
 
-    """Additional serialization help from the DRF parser/renderer"""
+    """Additional serialization help from the DRF renderer"""
 
     key = 'json-drf'
-
-    def loads(self, data):
-        return JSONParser().parse(data)
 
     def dumps(self, data):
         return JSONRenderer().render(data)


### PR DESCRIPTION
This reverts the workaround for single call previously committed and instead provides a generic solution.