### PR TITLE
Adds api to fetch related documents by tags

### DIFF
--- a/readthedocs/docsitalia/models.py
+++ b/readthedocs/docsitalia/models.py
@@ -14,6 +14,7 @@ from django.core.urlresolvers import reverse
 from readthedocs.projects.models import Project
 from readthedocs.oauth.models import RemoteOrganization
 
+from readthedocs.core.resolver import resolver
 from .utils import load_yaml
 
 
@@ -152,6 +153,10 @@ class Publisher(models.Model):
         """Get absolute url for publisher"""
         return reverse('publisher_detail', args=[self.slug])
 
+    def get_canonical_url(self):
+        """Get canonical url for publisher"""
+        return resolver.resolve_docsitalia(self.slug)
+
 
 @python_2_unicode_compatible
 class PublisherProject(models.Model):
@@ -190,6 +195,10 @@ class PublisherProject(models.Model):
     def get_absolute_url(self):
         """get absolute url for publisher project"""
         return reverse('publisher_project_detail', args=[self.publisher.slug, self.slug])
+
+    def get_canonical_url(self):
+        """get canonical url for publisher project"""
+        return resolver.resolve_docsitalia(self.publisher.slug, self.slug)
 
 
 @python_2_unicode_compatible

--- a/readthedocs/docsitalia/resolver.py
+++ b/readthedocs/docsitalia/resolver.py
@@ -87,3 +87,24 @@ class ItaliaResolver(ResolverBase):
         """
         protocol = getattr(settings, 'PUBLIC_PROTO', 'https')
         return super(ItaliaResolver, self).resolve(project, protocol, filename, private, **kwargs)
+
+    @staticmethod
+    def resolve_docsitalia(publisher_slug, pb_project_slug=None, protocol='http'):
+        """
+        Resolve the complete URL for a publisher or a publisher project
+
+        :param publisher_slug: the publisher slug
+        :param pb_project_slug: the publisher project slug
+        :param protocol: http / https protocol
+        """
+        domain = getattr(settings, 'PRODUCTION_DOMAIN')
+        protocol = getattr(settings, 'PUBLIC_PROTO', 'https')
+        if pb_project_slug:
+            path = u'{}/{}'.format(publisher_slug, pb_project_slug)
+        else:
+            path = publisher_slug
+        return u'{}://{}/{}'.format(
+            protocol,
+            domain,
+            path
+        )

--- a/readthedocs/docsitalia/serializers.py
+++ b/readthedocs/docsitalia/serializers.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""Docs italia serializers"""
+from __future__ import absolute_import
+
+from rest_framework import serializers
+from readthedocs.restapi.serializers import ProjectSerializer
+
+
+class DocsItaliaProjectSerializer(ProjectSerializer):
+
+    """Projects by Tag DRF Serializer"""
+
+    publisher = serializers.SerializerMethodField()
+    publisher_project = serializers.SerializerMethodField()
+
+    class Meta(ProjectSerializer.Meta):
+        fields = (
+            'id', 'name', 'slug', 'description',
+            'canonical_url', 'publisher', 'publisher_project',
+        )
+
+    @staticmethod
+    def get_publisher(obj):
+        """gets the publisher"""
+        p_p = obj.publisherproject_set.first()
+        if p_p.publisher:
+            return {
+                'name': p_p.publisher.metadata.get('name', ''),
+                'canonical_url': p_p.publisher.get_canonical_url()
+            }
+
+    @staticmethod
+    def get_publisher_project(obj):
+        """gets the publisher project"""
+        p_p = obj.publisherproject_set.first()
+        return {
+            'name': p_p.metadata.get('name', ''),
+            'canonical_url': p_p.get_canonical_url()
+        }

--- a/readthedocs/docsitalia/urls.py
+++ b/readthedocs/docsitalia/urls.py
@@ -3,12 +3,16 @@ from __future__ import absolute_import
 from django.conf.urls import include, url
 
 from readthedocs.constants import pattern_opts
+from rest_framework import routers
 
 from .views.core_views import DocsItaliaHomePage, PublisherIndex, PublisherProjectIndex
-from .views import integrations
+from .views import integrations, api
 
+router = routers.DefaultRouter()
+router.register(r'projects-by-tag', api.ProjectsByTagViewSet, base_name='projects-by-tag')
 
 docsitalia_urls = [
+    url(r'^api/', include(router.urls)),
     url(r'webhook/github/(?P<publisher_slug>{project_slug})/$'.format(**pattern_opts),
         integrations.MetadataGitHubWebhookView.as_view(),
         name='metadata_webhook_github'),
@@ -20,6 +24,7 @@ docsitalia_urls = [
 
 
 urlpatterns = [
+    url(r'^docsitalia/', include(docsitalia_urls)),
     url(
         r'^$',
         DocsItaliaHomePage.as_view(),
@@ -35,5 +40,4 @@ urlpatterns = [
         PublisherProjectIndex.as_view(),
         name='publisher_project_detail'
     ),
-    url(r'^docsitalia/', include(docsitalia_urls)),
 ]

--- a/readthedocs/docsitalia/views/api.py
+++ b/readthedocs/docsitalia/views/api.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Docs italia api"""
+from __future__ import absolute_import
+
+from rest_framework import viewsets
+from rest_framework import mixins
+
+from readthedocs.projects.models import Project
+
+from ..serializers import DocsItaliaProjectSerializer
+
+
+class ProjectsByTagViewSet(
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet
+):  # pylint: disable=too-many-ancestors
+
+    """
+    Projects by Tag DRF list model mixin
+
+    Takes a GET with tags separated by a comma:
+    tags=tag1,tag2
+    """
+
+    serializer_class = DocsItaliaProjectSerializer
+    allowed_methods = ('GET',)
+
+    def get_queryset(self):
+        """filter projects by tags"""
+        tags = self.request.query_params.get('tags', None)
+        if tags:
+            tags = tags.split(',')
+            queryset = Project.objects.filter(tags__slug__in=tags).distinct()
+        else:
+            queryset = Project.objects.none()
+        return queryset

--- a/readthedocs/settings/itresolver_testdocsitalia.py
+++ b/readthedocs/settings/itresolver_testdocsitalia.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+import os
+
+from .test import CommunityTestSettings
+
+
+CommunityTestSettings.load_settings(__name__)
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'PREFIX': 'docs',
+    }
+}
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'USER': '',
+        'HOST': '',
+        'PORT': 5433,
+        'PASSWORD': '',
+        'NAME': 'test_docsitalia'
+    }
+}
+
+# Override classes
+CLASS_OVERRIDES = {
+    'readthedocs.builds.syncers.Syncer': 'readthedocs.builds.syncers.LocalSyncer',
+    'readthedocs.core.resolver.Resolver': 'readthedocs.docsitalia.resolver.ItaliaResolver',
+    'readthedocs.oauth.services.GitHubService': 'readthedocs.docsitalia.oauth.services.github.DocsItaliaGithubService',  # noqa
+}
+
+
+if not os.environ.get('DJANGO_SETTINGS_SKIP_LOCAL', False):
+    try:
+        from .test_local_settings import *  # noqa
+    except ImportError:
+        pass

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,17 @@ changedir = {toxinidir}/readthedocs
 commands =
     py.test {posargs}
 
+[testenv:itresolver]
+description = run test with CLASS_OVERRIDES dict
+setenv =
+    PYTHONPATH={toxinidir}/readthedocs:{toxinidir}
+    DJANGO_SETTINGS_MODULE=readthedocs.settings.itresolver_testdocsitalia
+    LANG=C
+deps = -r{toxinidir}/requirements/testing-docsitalia.txt
+changedir = {toxinidir}/readthedocs
+commands =
+    py.test -v -m itresolver {posargs}
+
 [testenv:docs]
 description = build readthedocs documentation
 changedir = {toxinidir}/docs


### PR DESCRIPTION
Adds a django rest list view to get related projects. 
This
/docsitalia/api/projects-by-tag/?tags=comuni,anagrafe
will return:

```
{
    "count": 1,
    "next": null,
    "previous": null,
    "results": [
        {
            "id": 40,
            "name": "Matrimoni nel Comune di Tre Civette sul Comò",
            "slug": "matrimoni-delle-civette",
            "description": "Lorem ipsum dolor sit amet, consectetur \nadipisicing elit, sed do eiusmod tempor\nincididunt ut labore et dolore magna aliqua. \nUt enim ad minim veniam, quis nostrud \nexercitation ullamco laboris nisi ut \naliquip ex ea commodo consequat.\nDuis aute irure dolor in reprehenderit in \nvoluptate velit esse cillum dolore eu\nfugiat nulla pariatur. Excepteur sint \noccaecat cupidatat non proident, sunt in\nculpa qui officia deserunt mollit anim id \nest laborum.",
            "canonical_url": "http://localhost:8000/docs/matrimoni-delle-civette/en/bozza/",
            "publisher": {
                "name": "ANPR - Anagrafe Nazionale Popolazione Residente",
                "canonical_url": "http://localhost:8000/ANPR-Anagrafe-Nazionale-Popolazione-Residente/"
            },
            "publisher_project": {
                "canonica_url": "http://localhost:8000/ANPR-Anagrafe-Nazionale-Popolazione-Residente/lorem/",
                "name": "Lorem"
            }
        }
    ]
}
```