### PR TITLE
projects: serve badge with same protocol as resolver

### DIFF
--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -89,10 +89,7 @@ class ProjectDetailView(BuildTriggerMixin, ProjectOnboardMixin, DetailView):
         context['versions'] = Version.objects.public(
             user=self.request.user, project=project)
 
-        protocol = 'http'
-        if self.request.is_secure():
-            protocol = 'https'
-
+        protocol = getattr(settings, 'PUBLIC_PROTO', 'https')
         version_slug = project.get_default_version()
 
         context['badge_url'] = '%s://%s%s?version=%s' % (


### PR DESCRIPTION
Instead of request.is_secure use settings.PUBLIC_PROTO
to find out if we should serve the badge under https or not.
That matches what the resolver is doing and works here.