### PR TITLE
docsitalia: extend the api for filtering by project and publisher

### DIFF
--- a/readthedocs/docsitalia/urls.py
+++ b/readthedocs/docsitalia/urls.py
@@ -9,7 +9,7 @@ from .views.core_views import DocsItaliaHomePage, PublisherIndex, PublisherProje
 from .views import integrations, api
 
 router = routers.DefaultRouter()
-router.register(r'project', api.DocsItaliaProjectViewSet, base_name='docsitalia-project')
+router.register(r'document', api.DocsItaliaProjectViewSet, base_name='docsitalia-document')
 
 docsitalia_urls = [
     url(r'^api/', include(router.urls)),

--- a/readthedocs/docsitalia/views/api.py
+++ b/readthedocs/docsitalia/views/api.py
@@ -16,9 +16,9 @@ class DocsItaliaProjectViewSet(ProjectViewSet):  # pylint: disable=too-many-ance
 
     def get_queryset(self):
         """
-        Filter projects by tags and publisher passed as query parameters
+        Filter projects by tags, publisher and project passed as query parameters
 
-        e.g. ?tags=tag1,tag2, ?publisher=publisher-slug
+        e.g. ?tags=tag1,tag2, ?publisher=publisher-slug, ?project=project-slug
 
         """
         qs = super(DocsItaliaProjectViewSet, self).get_queryset()
@@ -29,4 +29,7 @@ class DocsItaliaProjectViewSet(ProjectViewSet):  # pylint: disable=too-many-ance
         publisher = self.request.query_params.get('publisher', None)
         if publisher:
             qs = qs.filter(publisherproject__publisher__slug=publisher)
+        project = self.request.query_params.get('project', None)
+        if project:
+            qs = qs.filter(publisherproject__slug=project)
         return qs

--- a/readthedocs/docsitalia/views/api.py
+++ b/readthedocs/docsitalia/views/api.py
@@ -16,14 +16,17 @@ class DocsItaliaProjectViewSet(ProjectViewSet):  # pylint: disable=too-many-ance
 
     def get_queryset(self):
         """
-        Filter projects by tags
+        Filter projects by tags and publisher passed as query parameters
 
-        Takes a GET with tags separated by a comma:
-        tags=tag1,tag2
+        e.g. ?tags=tag1,tag2, ?publisher=publisher-slug
+
         """
         qs = super(DocsItaliaProjectViewSet, self).get_queryset()
         tags = self.request.query_params.get('tags', None)
         if tags:
             tags = tags.split(',')
             qs = qs.filter(tags__slug__in=tags).distinct()
+        publisher = self.request.query_params.get('publisher', None)
+        if publisher:
+            qs = qs.filter(publisherproject__publisher__slug=publisher)
         return qs

--- a/readthedocs/rtd_tests/tests/test_docsitalia.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia.py
@@ -662,6 +662,60 @@ class DocsItaliaTest(TestCase):
         self.assertEqual(len(response.data['results']), 1)
         self.assertEqual(response.data['results'][0]['slug'], 'myprojectslug')
 
+    @pytest.mark.skipif(not IT_RESOLVER_IN_SETTINGS, reason='Require CLASS_OVERRIEDS in the settings file to work')
+    @pytest.mark.itresolver
+    @override_settings(PUBLIC_PROTO='http', PUBLIC_DOMAIN='readthedocs.org')
+    def test_projects_by_tag_api_filter_publisher_project(self):
+        project = Project.objects.create(
+            name='my project',
+            slug='myprojectslug',
+            repo='https://github.com/testorg/myrepourl.git'
+        )
+        project.tags.add('lorem', 'ipsum')
+        publisher = Publisher.objects.create(
+            name='Test Org',
+            slug='testorg',
+            metadata={},
+            projects_metadata={},
+            active=True
+        )
+        pub_project = PublisherProject.objects.create(
+            name='Test Project',
+            slug='testproject',
+            metadata={
+                'documents': [
+                    'https://github.com/testorg/myrepourl',
+                    'https://github.com/testorg/anotherrepourl',
+                ]
+            },
+            publisher=publisher,
+            active=True
+        )
+        pub_project.projects.add(project)
+
+        other_project = Project.objects.create(
+            name='my other project',
+            slug='myotherprojectslug',
+            repo='https://github.com/testorg/myrepourl.git'
+        )
+        other_pub_project = PublisherProject.objects.create(
+            name='Test other Project',
+            slug='testotherproject',
+            metadata={
+                'documents': [
+                    'https://github.com/othertestorg/myrepourl',
+                    'https://github.com/othertestorg/anotherrepourl',
+                ]
+            },
+            publisher=publisher,
+            active=True
+        )
+        other_pub_project.projects.add(other_project)
+
+        response = self.client.get(reverse('docsitalia-project-list'), {'project': 'testproject'})
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['slug'], 'myprojectslug')
+
     def test_projects_by_tag_api_no_tags_provided(self):
         project = Project.objects.create(
             name='my project',

--- a/readthedocs/rtd_tests/tests/test_docsitalia.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia.py
@@ -601,6 +601,67 @@ class DocsItaliaTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.skipif(not IT_RESOLVER_IN_SETTINGS, reason='Require CLASS_OVERRIEDS in the settings file to work')
+    @pytest.mark.itresolver
+    @override_settings(PUBLIC_PROTO='http', PUBLIC_DOMAIN='readthedocs.org')
+    def test_projects_by_tag_api_filter_publisher(self):
+        project = Project.objects.create(
+            name='my project',
+            slug='myprojectslug',
+            repo='https://github.com/testorg/myrepourl.git'
+        )
+        publisher = Publisher.objects.create(
+            name='Test Org',
+            slug='testorg',
+            metadata={},
+            projects_metadata={},
+            active=True
+        )
+        pub_project = PublisherProject.objects.create(
+            name='Test Project',
+            slug='testproject',
+            metadata={
+                'documents': [
+                    'https://github.com/testorg/myrepourl',
+                    'https://github.com/testorg/anotherrepourl',
+                ]
+            },
+            publisher=publisher,
+            active=True
+        )
+        pub_project.projects.add(project)
+
+        other_project = Project.objects.create(
+            name='my other project',
+            slug='myotherprojectslug',
+            repo='https://github.com/testorg/myrepourl.git'
+        )
+        other_publisher = Publisher.objects.create(
+            name='Test Org',
+            slug='othertestorg',
+            metadata={},
+            projects_metadata={},
+            active=True
+        )
+        other_pub_project = PublisherProject.objects.create(
+            name='Test other Project',
+            slug='testotherproject',
+            metadata={
+                'documents': [
+                    'https://github.com/othertestorg/myrepourl',
+                    'https://github.com/othertestorg/anotherrepourl',
+                ]
+            },
+            publisher=other_publisher,
+            active=True
+        )
+        other_pub_project.projects.add(other_project)
+
+        response = self.client.get(reverse('docsitalia-project-list'), {'publisher': 'testorg'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['slug'], 'myprojectslug')
+
     def test_projects_by_tag_api_no_tags_provided(self):
         project = Project.objects.create(
             name='my project',

--- a/readthedocs/rtd_tests/tests/test_docsitalia.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia.py
@@ -572,7 +572,7 @@ class DocsItaliaTest(TestCase):
             active=True
         )
         pub_project.projects.add(project)
-        response = self.client.get(reverse('docsitalia-project-list'), {'tags': 'lorem, sicut'})
+        response = self.client.get(reverse('docsitalia-document-list'), {'tags': 'lorem, sicut'})
         self.assertEqual(len(response.data['results']), 1)
         self.assertJSONEqual(
             response.content.decode('utf-8'), {
@@ -657,7 +657,7 @@ class DocsItaliaTest(TestCase):
         )
         other_pub_project.projects.add(other_project)
 
-        response = self.client.get(reverse('docsitalia-project-list'), {'publisher': 'testorg'})
+        response = self.client.get(reverse('docsitalia-document-list'), {'publisher': 'testorg'})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         self.assertEqual(response.data['results'][0]['slug'], 'myprojectslug')
@@ -712,7 +712,7 @@ class DocsItaliaTest(TestCase):
         )
         other_pub_project.projects.add(other_project)
 
-        response = self.client.get(reverse('docsitalia-project-list'), {'project': 'testproject'})
+        response = self.client.get(reverse('docsitalia-document-list'), {'project': 'testproject'})
         self.assertEqual(len(response.data['results']), 1)
         self.assertEqual(response.data['results'][0]['slug'], 'myprojectslug')
 
@@ -723,7 +723,7 @@ class DocsItaliaTest(TestCase):
             repo='https://github.com/testorg/myrepourl.git'
         )
         project.tags.add('lorem', 'ipsum')
-        response = self.client.get(reverse('docsitalia-project-list'))
+        response = self.client.get(reverse('docsitalia-document-list'))
         self.assertTrue(response.data['results'])
         self.assertEqual(response.status_code, 200)
 
@@ -734,7 +734,7 @@ class DocsItaliaTest(TestCase):
             repo='https://github.com/testorg/myrepourl.git'
         )
         project.tags.add('lorem', 'ipsum')
-        response = self.client.get(reverse('docsitalia-project-list'), {'tags': 'sicut, amet'})
+        response = self.client.get(reverse('docsitalia-document-list'), {'tags': 'sicut, amet'})
         self.assertEqual(len(response.data['results']), 0)
         self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION
While at it move our api under a document prefix to match the frontend nomenclature.