### PR TITLE
docsitalia: implement our own import view

### DIFF
--- a/readthedocs/docsitalia/urls.py
+++ b/readthedocs/docsitalia/urls.py
@@ -1,13 +1,15 @@
 from __future__ import absolute_import
 
 from django.apps import apps
+from django.conf import settings
 from django.conf.urls import include, url
 from django.views.generic.base import TemplateView
 
 from readthedocs.constants import pattern_opts
 from rest_framework import routers
 
-from .views.core_views import DocsItaliaHomePage, PublisherIndex, PublisherProjectIndex
+from .views.core_views import (
+    DocsItaliaHomePage, PublisherIndex, PublisherProjectIndex, DocsItaliaImport)
 from .views import integrations, api
 
 router = routers.DefaultRouter()
@@ -22,6 +24,9 @@ docsitalia_urls = [
          r'(?P<integration_pk>{integer_pk})/$'.format(**pattern_opts)),
         integrations.MetadataWebhookView.as_view(),
         name='metadata_webhook'),
+    url(r'^dashboard/import/$',
+        DocsItaliaImport.as_view(),
+        name='projects_import'),
 ]
 
 urlpatterns = [

--- a/readthedocs/docsitalia/urls.py
+++ b/readthedocs/docsitalia/urls.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.apps import apps
 from django.conf import settings
 from django.conf.urls import include, url
-from django.views.generic.base import TemplateView
+from django.views.generic.base import RedirectView, TemplateView
 
 from readthedocs.constants import pattern_opts
 from rest_framework import routers
@@ -27,6 +27,12 @@ docsitalia_urls = [
     url(r'^dashboard/import/$',
         DocsItaliaImport.as_view(),
         name='projects_import'),
+    url(r'^dashboard/import/manual/$',
+        RedirectView.as_view(pattern_name='projects_import'),
+        name='projects_import_manual'),
+    url(r'^dashboard/import/manual/demo/$',
+        RedirectView.as_view(pattern_name='projects_import'),
+        name='projects_import_demo'),
 ]
 
 urlpatterns = [

--- a/readthedocs/docsitalia/views/core_views.py
+++ b/readthedocs/docsitalia/views/core_views.py
@@ -4,11 +4,23 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import logging
+
+from django.shortcuts import render, redirect
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic import DetailView, ListView
 
 from readthedocs.builds.models import Version
-from readthedocs.docsitalia.models import PublisherProject, Publisher
+from readthedocs.core.utils import trigger_build
+from readthedocs.projects.forms import ProjectBasicsForm, ProjectExtraForm
 from readthedocs.projects.models import Project
+from readthedocs.projects.signals import project_import
+from readthedocs.projects.views.private import ImportView
+
+from ..github import get_metadata_for_document, InvalidMetadata
+from ..models import PublisherProject, Publisher
+
+log = logging.getLogger(__name__)  # noqa
 
 
 class DocsItaliaHomePage(ListView):  # pylint: disable=too-many-ancestors
@@ -70,3 +82,38 @@ class PublisherProjectIndex(DetailView):  # pylint: disable=too-many-ancestors
             active=True,
             publisher__active=True
         )
+
+
+class DocsItaliaImport(ImportView):  # pylint: disable=too-many-ancestors
+
+    """Simplified ImportView for Docs Italia"""
+
+    def post(self, request, *args, **kwargs):
+        """Validate metadata before importing the project"""
+        form = ProjectBasicsForm(request.POST, user=request.user)
+        project = form.save(commit=False)
+
+        try:
+            get_metadata_for_document(project)
+        except InvalidMetadata:
+            log.error(
+                'Failed to import document invalid metadata')
+            msg = _('Invalid document_settings.yml found in the repository')
+            return render(request, 'docsitalia/import_error.html', {'error_msg': msg})
+        except Exception as e: # noqa
+            log.error(
+                'Failed to import document metadata: %s', e)
+            msg = _('Failed to download document_settings.yml from the repository')
+            return render(request, 'docsitalia/import_error.html', {'error_msg': msg})
+
+        extra_fields = ProjectExtraForm.Meta.fields
+        for field, value in request.POST.items():
+            if field in extra_fields:
+                setattr(project, field, value)
+        project.save()
+        project.users.add(request.user)
+
+        # FIXME: move what we are doing in our signal handler here
+        project_import.send(sender=project, request=self.request)
+        trigger_build(project, basic=True)
+        return redirect('projects_detail', project_slug=project.slug)

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -227,7 +227,8 @@ class PrivateProjectAdminAccessTest(PrivateProjectMixin, TestCase):
 
     response_data = {
         # Places where we 302 on success -- These delete pages should probably be 405'ing
-        '/dashboard/import/manual/demo/': {'status_code': 302},
+        '/docsitalia/dashboard/import/manual/demo/': {'status_code': 302},
+        '/docsitalia/dashboard/import/manual/': {'status_code': 302},
         '/dashboard/pip/': {'status_code': 302},
         '/dashboard/pip/subprojects/delete/sub/': {'status_code': 302},
         '/dashboard/pip/translations/delete/sub/': {'status_code': 302},
@@ -263,8 +264,8 @@ class PrivateProjectUserAccessTest(PrivateProjectMixin, TestCase):
         # Auth'd users can import projects, have no perms on pip
         '/dashboard/': {'status_code': 200},
         '/docsitalia/dashboard/import/': {'status_code': 200},
-        '/dashboard/import/manual/': {'status_code': 200},
-        '/dashboard/import/manual/demo/': {'status_code': 302},
+        '/docsitalia/dashboard/import/manual/': {'status_code': 302},
+        '/docsitalia/dashboard/import/manual/demo/': {'status_code': 302},
 
         # Unauth access redirect for non-owners
         '/dashboard/pip/': {'status_code': 302},

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -262,7 +262,7 @@ class PrivateProjectUserAccessTest(PrivateProjectMixin, TestCase):
     response_data = {
         # Auth'd users can import projects, have no perms on pip
         '/dashboard/': {'status_code': 200},
-        '/dashboard/import/': {'status_code': 200},
+        '/docsitalia/dashboard/import/': {'status_code': 200},
         '/dashboard/import/manual/': {'status_code': 200},
         '/dashboard/import/manual/demo/': {'status_code': 302},
 

--- a/readthedocs/templates/docsitalia/import_error.html
+++ b/readthedocs/templates/docsitalia/import_error.html
@@ -1,0 +1,8 @@
+{% extends "projects/import_base.html" %}
+{% load i18n %}
+
+{% block content %}
+  <h3>{% trans "Error" %}</h3>
+
+  <p class="error">{{ error_msg }}</p>
+{% endblock %}

--- a/readthedocs/templates/docsitalia/overrides/projects/onboard_import.html
+++ b/readthedocs/templates/docsitalia/overrides/projects/onboard_import.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+
+<!-- BEGIN onboard import project -->
+<div class="onboard onboard-import-project">
+  <h2>{% trans "Ready to share your documentation" %}{% if request.user.first_name %}, {{ request.user.first_name }}{% endif %}?</h2>
+
+  {% with getting_started_url="http://docs.readthedocs.io/en/latest/getting_started.html" %}
+    <form method="get" action="{% url "projects_import" %}">
+      <p>
+        {% blocktrans %}
+          You don't have any projects yet, but you can start building documentation by importing one.
+          Not sure how to start documenting your project?
+          Check out the <a href="{{ getting_started_url }}">Getting Started Guide</a> to learn how.
+        {% endblocktrans %}
+      </p>
+
+      <input type="submit" value="{% trans "Import a Project" %}"/>
+    </form>
+  {% endwith %}
+</div>
+<!-- END onboard import project -->

--- a/readthedocs/templates/docsitalia/overrides/projects/project_import.html
+++ b/readthedocs/templates/docsitalia/overrides/projects/project_import.html
@@ -194,18 +194,6 @@
     <div class="col-minor project-import-sidebar">
 
       {% block manual-import %}
-        <div class="import-manual">
-          <p>
-            {% blocktrans trimmed %}
-              You can import your project manually if it isn't listed here or
-              connected to one of your accounts.
-            {% endblocktrans %}
-          </p>
-
-          <form action="{% url "projects_import_manual" %}" method="get" class="import-manual">
-            <button type="submit" class="btn btn-primary">{% trans "Import Manually" %}</button>
-          </form>
-        </div>
       {% endblock %}
 
       {% block filter-repositories %}


### PR DESCRIPTION
The idea is to avoid the form wizard for filling the projects data and instead check the presence and the validity of the document_settings.yml giving feedback to the user in case of problems. 