### PR TITLE
Commit ProjectBasicsForm.save() otherwise related repo is not saved

### DIFF
--- a/readthedocs/docsitalia/views/core_views.py
+++ b/readthedocs/docsitalia/views/core_views.py
@@ -91,7 +91,7 @@ class DocsItaliaImport(ImportView):  # pylint: disable=too-many-ancestors
     def post(self, request, *args, **kwargs):
         """Validate metadata before importing the project"""
         form = ProjectBasicsForm(request.POST, user=request.user)
-        project = form.save(commit=False)
+        project = form.save()
 
         try:
             get_metadata_for_document(project)

--- a/readthedocs/rtd_tests/tests/test_docsitalia_views.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia_views.py
@@ -34,6 +34,7 @@ class DocsItaliaViewsTest(TestCase):
         remote = RemoteRepository.objects.create(
             full_name='remote repo name',
             html_url='https://github.com/testorg/myrepourl',
+            ssh_url='https://github.com/org-docs-italia/altro-progetto.git',
         )
         remote.users.add(eric)
 
@@ -107,7 +108,7 @@ class DocsItaliaViewsTest(TestCase):
         version = Version.objects.first()
         version.privacy_level = 'private'
         version.save()
-   
+
         qs = hp.get_queryset()
         self.assertFalse(qs.exists())
 
@@ -203,6 +204,8 @@ class DocsItaliaViewsTest(TestCase):
             rm.get(self.document_settings_url, text=DOCUMENT_METADATA)
             response = self.client.post(
                 '/docsitalia/dashboard/import/', data=self.import_project_data)
-        project = Project.objects.last()
+        project = Project.objects.get(repo=self.import_project_data['repo'])
+        repo = RemoteRepository.objects.get(ssh_url=project.repo)
+        self.assertEqual(repo.project, project)
         redirect_url = reverse('projects_detail', kwargs={'project_slug': 'altro-progetto'})
         self.assertRedirects(response, redirect_url)


### PR DESCRIPTION
We need to commit ProjectBasicsForm.save otherwise relate RemoteRepository does not save relationship with the project created by the form
If `form.save(commit=False)`, then `instance.remote_repository_id` at https://github.com/italia/docs.italia.it/blob/italia-2.3.13/readthedocs/projects/forms.py#L111 is `None` as project has no `pk` at that point
The alternative implementation is to set the project in the repository again after this https://github.com/italia/docs.italia.it/blob/italia-2.3.13/readthedocs/docsitalia/views/core_views.py#L113 and save `remote_repo`