### PR TITLE
Fix tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands =
     py.test {posargs}
 
 [testenv:itresolver]
+basepython = python3.6
 description = run test with CLASS_OVERRIDES dict
 setenv =
     PYTHONPATH={toxinidir}/readthedocs:{toxinidir}


### PR DESCRIPTION
Force python 3.6 version in tox to match the one used on travis