### PR TITLE
search: avoid elastic search returning hits with very low score

### DIFF
--- a/readthedocs/search/lib.py
+++ b/readthedocs/search/lib.py
@@ -76,6 +76,8 @@ def search_file(request, query, project_slug=None, version_slug=LATEST, taxonomy
     """
     kwargs = {}
     body = {
+        # avoid elastic search returning hits with very low score
+        "min_score": getattr(settings, 'ES_SEARCH_FILE_MIN_SCORE', 1),
         "query": {
             "bool": {
                 "should": [


### PR DESCRIPTION
For some reason ES returns hits with score 0 in the file search.
This goes unnoticed when the hits return something sensible but
in the case the query does not match anything we don't want to
throw random stuff at the user. So we add a completely arbitrary
min_score of 1 to avoid unwanted hits.