### PR TITLE
provide the _id to es to reindex the same objects

### DIFF
--- a/readthedocs/search/indexes.py
+++ b/readthedocs/search/indexes.py
@@ -128,6 +128,7 @@ class Index(object):
                 '_index': index,
                 '_type': self._type,
                 '_source': source,
+                '_id': d['id'],
             }
             if routing:
                 doc['_routing'] = routing


### PR DESCRIPTION
Provide the _id to es to reindex the same objects in order to fix duplication in the ES index.