### PR TITLE
projects: remove unwanted entries from document detail page

### DIFF
--- a/readthedocs/templates/docsitalia/overrides/core/project_bar_base.html
+++ b/readthedocs/templates/docsitalia/overrides/core/project_bar_base.html
@@ -55,11 +55,7 @@
 
         <li class="{{ downloads_active }}"><a href="{% url "project_downloads" project.slug %}" rel="nofollow,noindex">{% trans "Downloads" %}</a></li>
 
-        <li class="{{ search_active }}"><a href="{% url "elastic_project_search" project.slug %}" rel="nofollow,noindex">{% trans "Search" %}</a></li>
-
         <li class="{{ builds_active }}"><a href="{{ project.get_builds_url }}">{% trans "Builds" %}</a></li>
-
-        <li class="{{ versions_active }}"><a href="{% url "project_version_list" project.slug %}">{% trans "Versions" %}</a></li>
 
         {% if request.user|is_admin:project %}
           <li class="{{ edit_active }} project-admin"><a href="{% url "projects_edit" project.slug %}"><i class="gear"></i>{% trans "Admin" %}</a></li>

--- a/readthedocs/templates/docsitalia/overrides/projects/project_edit_base.html
+++ b/readthedocs/templates/docsitalia/overrides/projects/project_edit_base.html
@@ -15,18 +15,10 @@
     <div class="navigable row">
       <ul class="project_edit__menu col-3 col-sm-4 col-md-3 col-xl-2">
         <li class="{% block project-edit-active %}{% endblock %}"><a href="{% url "projects_edit" project.slug %}">{% trans "Settings" %} </a></li>
-        <li class="{% block project-advanced-active %}{% endblock %}"><a href="{% url "projects_advanced" project.slug %}">{% trans "Advanced Settings" %} </a></li>
         <li class="{% block project-versions-active %}{% endblock %}"><a href="{% url "projects_versions" project.slug %}" rel="nofollow,noindex">{% trans "Versions" %}</a></li>
-        <li class="{% block project-domains-active %}{% endblock %}"><a href="{% url "projects_domains" project.slug %}">{% trans "Domains" %}</a></li>
         <li class="{% block project-users-active %}{% endblock %}"><a href="{% url "projects_users" project.slug %}">{% trans "Maintainers" %}</a></li>
-        <li class="{% block project-redirects-active %}{% endblock %}"><a href="{% url "projects_redirects" project.slug %}">{% trans "Redirects" %}</a></li>
-        <li class="{% block project-translations-active %}{% endblock %}"><a href="{% url "projects_translations" project.slug %}">{% trans "Translations" %}</a></li>
-        <li class="{% block project-subprojects-active %}{% endblock %}"><a href="{% url "projects_subprojects" project.slug %}">{% trans "Subprojects" %}</a></li>
         <li class="{% block project-integrations-active %}{% endblock %}"><a href="{% url "projects_integrations" project.slug %}">{% trans "Integrations" %}</a></li>
         <li class="{% block project-notifications-active %}{% endblock %}"><a href="{% url "projects_notifications" project.slug %}">{% trans "Notifications" %}</a></li>
-        {% if USE_PROMOS %}
-          <li class="{% block project-ads-active %}{% endblock %}"><a href="{% url "projects_advertising" project.slug %}">{% trans "Advertising" %} </a></li>
-        {% endif %}
       </ul>
       <div class="project_edit__form col-9 col-sm-8 col-md-9 col-xl-10">
         <h2>{% block project_edit_content_header %}{% endblock %}</h2>


### PR DESCRIPTION
Remove things we don't want to show to the user or does not apply
to our platform from both the project top bar and the left menu in
the administration tab.