### PR TITLE
Removes file type search from homepage

### DIFF
--- a/readthedocs/templates/docsitalia/includes/searchbar.html
+++ b/readthedocs/templates/docsitalia/includes/searchbar.html
@@ -4,12 +4,10 @@
 <h2 class="text-white">Cerca</h2>
 
 
-
 <form action="{% url "search" %}" method="GET">
   <div class="form-row align-items-center">
     <div class="col-auto">
       <label class="sr-only" for="id_site_search">Cerca</label>
-      <input type="hidden" name="type" value="file">
       <input type="text" class="form-control bg-white" name="q" value="{{ term }}" id="id_site_search" placeholder="{% trans 'Search Read the Docs' %}">
     </div>
     <div class="col-auto">
@@ -17,6 +15,3 @@
     </div>
   </div>
 </form>
-
-
-


### PR DESCRIPTION
Since we don't provide the file type search we need to remove it also from the homepage form.