### PR TITLE
Adds cmd to remove projects without publisher from the ES index

### DIFF
--- a/readthedocs/core/management/commands/provision_elasticsearch.py
+++ b/readthedocs/core/management/commands/provision_elasticsearch.py
@@ -1,0 +1,33 @@
+"""Provision Elastic Search"""
+
+from __future__ import absolute_import
+import logging
+
+from django.core.management.base import BaseCommand
+
+from readthedocs.search.indexes import Index, PageIndex, ProjectIndex, SectionIndex
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+
+    help = __doc__
+
+    def handle(self, *args, **options):
+        """Provision new ES instance"""
+        index = Index()
+        index_name = index.timestamped_index()
+
+        log.info("Creating indexes..")
+        index.create_index(index_name)
+        index.update_aliases(index_name)
+
+        log.info("Updating mappings..")
+        proj = ProjectIndex()
+        proj.put_mapping()
+        page = PageIndex()
+        page.put_mapping()
+        sec = SectionIndex()
+        sec.put_mapping()
+        log.info("Done!")

--- a/readthedocs/docsitalia/admin.py
+++ b/readthedocs/docsitalia/admin.py
@@ -28,13 +28,22 @@ class PublisherAdmin(admin.ModelAdmin):
             )
         }),
     )
+    list_display = ('name', 'remote_organization', 'pub_date',)
+    list_filter = ('active',)
 
 
 class PublisherProjectAdmin(admin.ModelAdmin):
 
     """Admin view for :py:class:`PublisherProject`"""
 
-    list_filter = ('featured',)
+    list_filter = ('featured', 'active',)
+    list_display = ('name', 'publisher', 'documents', 'pub_date',)
+
+    # pylint: disable=R0201
+    def documents(self, obj):
+        """Return the number of linked projects"""
+        return obj.projects.count()
+    documents.short_description = _('documents')
 
 
 admin.site.register(Publisher, PublisherAdmin)

--- a/readthedocs/docsitalia/management/commands/clean_es_index.py
+++ b/readthedocs/docsitalia/management/commands/clean_es_index.py
@@ -2,23 +2,41 @@
 from __future__ import (
     absolute_import, print_function)
 
+from django.db.models import Q
 from django.core.management.base import BaseCommand
+from django.conf import settings
 
 from elasticsearch import Elasticsearch
 from readthedocs.projects.models import Project
 
+from readthedocs.docsitalia.models import PublisherProject
+
 
 class Command(BaseCommand):
 
-    """Removes projects without publisher from the ES index"""
+    """
+    Clean ES index:
+
+    Removes projects without publisher or inactive publisher or
+    inactive publisher project from the ES index.
+    Delete projects not linked to a publisher project from the db.
+    """
 
     def handle(self, *args, **options):
         """handle command"""
-        e_s = Elasticsearch()
-        for p_o in Project.objects.filter(publisherproject__isnull=True):
+        e_s = Elasticsearch(settings.ES_HOSTS)
+        inactive_pp = PublisherProject.objects.filter(
+            Q(active=False) | Q(publisher__active=False)
+        ).values_list('pk', flat=True)
+        queryset = Project.objects.filter(
+            Q(publisherproject__isnull=True) | Q(publisherproject__in=inactive_pp)
+        )
+        for p_o in queryset:
             print(p_o.name)
             print(p_o.get_absolute_url())
             print(p_o.pk)
             if e_s.exists(index='readthedocs', doc_type='project', id=p_o.pk):
                 e_s.delete(index='readthedocs', doc_type='project', id=p_o.pk)
+            if p_o.publisherproject_set.count() == 0:
+                p_o.delete()
             print('')

--- a/readthedocs/docsitalia/management/commands/clean_es_index.py
+++ b/readthedocs/docsitalia/management/commands/clean_es_index.py
@@ -1,0 +1,24 @@
+"""Removes projects without publisher from the ES index"""
+from __future__ import (
+    absolute_import, print_function)
+
+from django.core.management.base import BaseCommand
+
+from elasticsearch import Elasticsearch
+from readthedocs.projects.models import Project
+
+
+class Command(BaseCommand):
+
+    """Removes projects without publisher from the ES index"""
+
+    def handle(self, *args, **options):
+        """handle command"""
+        e_s = Elasticsearch()
+        for p_o in Project.objects.filter(publisherproject__isnull=True):
+            print(p_o.name)
+            print(p_o.get_absolute_url())
+            print(p_o.pk)
+            if e_s.exists(index='readthedocs', doc_type='project', id=p_o.pk):
+                e_s.delete(index='readthedocs', doc_type='project', id=p_o.pk)
+            print('')


### PR DESCRIPTION
Adds a command that removes from the index all projects without publisher projects.
It also prints the absolute url of the project on the screen so that one can debug it.


We could add other clean functions here in the future.