### PR TITLE
WIP: Clean docs es index

### DIFF
--- a/readthedocs/docsitalia/management/commands/clean_es_index.py
+++ b/readthedocs/docsitalia/management/commands/clean_es_index.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
             try:
                 e_s.delete_by_query(
                     index='readthedocs', doc_type='page',
-                    body={'query': {'match': {'project': p_o.slug}}}
+                    body={'query': {'term': {'project_id': p_o.pk}}}
                 )
             except NotFoundError:
                 print('Index not found')

--- a/readthedocs/docsitalia/management/commands/clean_es_index.py
+++ b/readthedocs/docsitalia/management/commands/clean_es_index.py
@@ -36,7 +36,14 @@ class Command(BaseCommand):
             print(p_o.name, p_o.get_absolute_url(), p_o.pk)
             try:
                 e_s.delete(index='readthedocs', doc_type='project', id=p_o.pk)
-                e_s.delete_by_query(doc_type='page', body={'query': {'match': {'project': p_p.slug}}})
+
+            except NotFoundError:
+                print('Index not found')
+            try:
+                e_s.delete_by_query(
+                    index='readthedocs', doc_type='page',
+                    body={'query': {'match': {'project': p_o.slug}}}
+                )
             except NotFoundError:
                 print('Index not found')
             print('')

--- a/readthedocs/docsitalia/management/commands/clean_es_index.py
+++ b/readthedocs/docsitalia/management/commands/clean_es_index.py
@@ -7,7 +7,10 @@ from django.core.management.base import BaseCommand
 from django.conf import settings
 
 from elasticsearch import Elasticsearch
+<<<<<<< HEAD
 from elasticsearch.exceptions import NotFoundError
+=======
+>>>>>>> Clean docs es index
 from readthedocs.projects.models import Project
 
 from readthedocs.docsitalia.models import PublisherProject

--- a/readthedocs/docsitalia/management/commands/clean_es_index.py
+++ b/readthedocs/docsitalia/management/commands/clean_es_index.py
@@ -7,10 +7,7 @@ from django.core.management.base import BaseCommand
 from django.conf import settings
 
 from elasticsearch import Elasticsearch
-<<<<<<< HEAD
 from elasticsearch.exceptions import NotFoundError
-=======
->>>>>>> Clean docs es index
 from readthedocs.projects.models import Project
 
 from readthedocs.docsitalia.models import PublisherProject

--- a/readthedocs/docsitalia/management/commands/clean_es_index.py
+++ b/readthedocs/docsitalia/management/commands/clean_es_index.py
@@ -7,6 +7,7 @@ from django.core.management.base import BaseCommand
 from django.conf import settings
 
 from elasticsearch import Elasticsearch
+from elasticsearch.exceptions import NotFoundError
 from readthedocs.projects.models import Project
 
 from readthedocs.docsitalia.models import PublisherProject
@@ -35,8 +36,9 @@ class Command(BaseCommand):
             print(p_o.name)
             print(p_o.get_absolute_url())
             print(p_o.pk)
-            if e_s.exists(index='readthedocs', doc_type='project', id=p_o.pk):
+            try:
                 e_s.delete(index='readthedocs', doc_type='project', id=p_o.pk)
-            if p_o.publisherproject_set.count() == 0:
-                p_o.delete()
+            except NotFoundError:
+                print('Index not found')
             print('')
+        Project.objects.filter(publisherproject__isnull=True).delete()

--- a/readthedocs/docsitalia/management/commands/clean_es_index.py
+++ b/readthedocs/docsitalia/management/commands/clean_es_index.py
@@ -33,11 +33,10 @@ class Command(BaseCommand):
             Q(publisherproject__isnull=True) | Q(publisherproject__in=inactive_pp)
         )
         for p_o in queryset:
-            print(p_o.name)
-            print(p_o.get_absolute_url())
-            print(p_o.pk)
+            print(p_o.name, p_o.get_absolute_url(), p_o.pk)
             try:
                 e_s.delete(index='readthedocs', doc_type='project', id=p_o.pk)
+                e_s.delete_by_query(doc_type='page', body={'query': {'match': {'project': p_p.slug}}})
             except NotFoundError:
                 print('Index not found')
             print('')

--- a/readthedocs/docsitalia/management/commands/clean_es_index.py
+++ b/readthedocs/docsitalia/management/commands/clean_es_index.py
@@ -1,0 +1,42 @@
+"""Removes projects without publisher from the ES index"""
+from __future__ import (
+    absolute_import, print_function)
+
+from django.db.models import Q
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+from elasticsearch import Elasticsearch
+from readthedocs.projects.models import Project
+
+from readthedocs.docsitalia.models import PublisherProject
+
+
+class Command(BaseCommand):
+
+    """
+    Clean ES index:
+
+    Removes projects without publisher or inactive publisher or
+    inactive publisher project from the ES index.
+    Delete projects not linked to a publisher project from the db.
+    """
+
+    def handle(self, *args, **options):
+        """handle command"""
+        e_s = Elasticsearch(settings.ES_HOSTS)
+        inactive_pp = PublisherProject.objects.filter(
+            Q(active=False) | Q(publisher__active=False)
+        ).values_list('pk', flat=True)
+        queryset = Project.objects.filter(
+            Q(publisherproject__isnull=True) | Q(publisherproject__in=inactive_pp)
+        )
+        for p_o in queryset:
+            print(p_o.name)
+            print(p_o.get_absolute_url())
+            print(p_o.pk)
+            if e_s.exists(index='readthedocs', doc_type='project', id=p_o.pk):
+                e_s.delete(index='readthedocs', doc_type='project', id=p_o.pk)
+            if p_o.publisherproject_set.count() == 0:
+                p_o.delete()
+            print('')

--- a/readthedocs/docsitalia/management/commands/clean_es_index.py
+++ b/readthedocs/docsitalia/management/commands/clean_es_index.py
@@ -36,7 +36,6 @@ class Command(BaseCommand):
             print(p_o.name, p_o.get_absolute_url(), p_o.pk)
             try:
                 e_s.delete(index='readthedocs', doc_type='project', id=p_o.pk)
-
             except NotFoundError:
                 print('Index not found')
             try:

--- a/readthedocs/rtd_tests/tests/test_docsitalia.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia.py
@@ -1034,7 +1034,7 @@ class DocsItaliaTest(TestCase):
             repo='https://github.com/testorg/mysecondrepourl.git'
         )
         pub_project.projects.add(second_project)
-        with patch('elasticsearch.Elasticsearch.delete') as d:
+        with patch('elasticsearch.Elasticsearch.delete') as d, patch('elasticsearch.Elasticsearch.delete_by_query') as f :
             d.return_value = True
             call_command('clean_es_index')
             self.assertNotIn(second_project.pk, [e[1]['id'] for e in d.call_args_list])
@@ -1068,7 +1068,7 @@ class DocsItaliaTest(TestCase):
             repo='https://github.com/testorg/myrepourl.git'
         )
         pub_project.projects.add(project)
-        with patch('elasticsearch.Elasticsearch.delete') as d:
+        with patch('elasticsearch.Elasticsearch.delete') as d, patch('elasticsearch.Elasticsearch.delete_by_query') as f :
             d.return_value = True
             call_command('clean_es_index')
             self.assertIn(project.pk, [e[1]['id'] for e in d.call_args_list])
@@ -1099,7 +1099,7 @@ class DocsItaliaTest(TestCase):
             repo='https://github.com/testorg/myrepourl.git'
         )
         pub_project.projects.add(project)
-        with patch('elasticsearch.Elasticsearch.delete') as d:
+        with patch('elasticsearch.Elasticsearch.delete') as d,  patch('elasticsearch.Elasticsearch.delete_by_query') as f :
             d.return_value = True
             call_command('clean_es_index')
             self.assertIn(project.pk, [e[1]['id'] for e in d.call_args_list])


### PR DESCRIPTION
Clean ES index:
Removes projects without publisher or inactive publisher or inactive publisher project from the ES index.
Delete projects not linked to a publisher project from the db.