### PR TITLE
search: fixup elastic search indexes

### DIFF
--- a/readthedocs/core/management/commands/reindex_elasticsearch.py
+++ b/readthedocs/core/management/commands/reindex_elasticsearch.py
@@ -12,6 +12,8 @@ from django.core.management.base import BaseCommand, CommandError
 
 from readthedocs.builds.constants import LATEST
 from readthedocs.builds.models import Version
+from readthedocs.docsitalia.models import PublisherProject
+from readthedocs.projects.models import Project
 from readthedocs.projects.tasks import update_search
 
 log = logging.getLogger(__name__)
@@ -37,7 +39,18 @@ class Command(BaseCommand):
         project = options['project']
         only_latest = options['only_latest']
 
-        queryset = Version.objects.filter(active=True)
+        # index only projects with active publisher and publisher project
+        publisher_projects = PublisherProject.objects.filter(
+            active=True,
+            publisher__active=True
+        ).values_list('pk', flat=True)
+        projects = Project.objects.filter(
+            publisherproject__in=publisher_projects
+        ).values_list('pk', flat=True)
+        queryset = Version.objects.filter(
+            active=True,
+            project__in=projects,
+        )
 
         if project:
             queryset = queryset.filter(project__slug=project)

--- a/readthedocs/core/management/commands/reindex_elasticsearch.py
+++ b/readthedocs/core/management/commands/reindex_elasticsearch.py
@@ -5,7 +5,6 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
 import logging
-import socket
 from optparse import make_option
 
 from django.core.management.base import BaseCommand, CommandError
@@ -73,7 +72,6 @@ class Command(BaseCommand):
                         delete_non_commit_files=False
                     ),
                     priority=0,
-                    queue=socket.gethostname()
                 )
             except Exception:
                 log.exception(u'Reindexing failed for %s:%s' % (project_slug, version_slug))

--- a/readthedocs/restapi/utils.py
+++ b/readthedocs/restapi/utils.py
@@ -139,6 +139,7 @@ def index_search_request(
         index_list.append({
             'id': page_id,
             'project': project.slug,
+            'project_id': project.pk,
             'version': version.slug,
             'path': page['path'],
             'title': page['title'],

--- a/readthedocs/rtd_tests/tests/test_docsitalia_search.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia_search.py
@@ -109,5 +109,5 @@ class TestSearch(TestCase):
               'commit': None, 'progetto': 'testproject', 'path': 'path',
               'weight': 2, 'version': 'verbose-name', 'headers': 'headers',
               'id': 'b3129830187e487e332bb2eab1b7a9c3', 'title': 'title',
-              'content': 'content'}], routing='pip'
+              'content': 'content', 'project_id': self.pip.pk}], routing='pip'
         )

--- a/readthedocs/search/indexes.py
+++ b/readthedocs/search/indexes.py
@@ -274,6 +274,7 @@ class PageIndex(Index):
                     'id': {'type': 'keyword'},
                     'sha': {'type': 'keyword'},
                     'project': {'type': 'keyword'},
+                    'project_id': {'type': 'keyword'},
                     'version': {'type': 'keyword'},
                     'path': {'type': 'keyword'},
                     'taxonomy': {'type': 'keyword'},
@@ -295,7 +296,7 @@ class PageIndex(Index):
     def extract_document(self, data):
         doc = {}
 
-        attrs = ('id', 'project', 'title', 'headers', 'version', 'path',
+        attrs = ('id', 'project_id', 'project', 'title', 'headers', 'version', 'path',
                  'content', 'taxonomy', 'commit', 'progetto', 'publisher')
         for attr in attrs:
             doc[attr] = data.get(attr, '')

--- a/readthedocs/search/indexes.py
+++ b/readthedocs/search/indexes.py
@@ -284,13 +284,6 @@ class PageIndex(Index):
                     'content': {'type': 'text', 'analyzer': 'default_icu'},
                     # Add a weight field to enhance relevancy scoring.
                     'weight': {'type': 'float'},
-                    # Associate a page with a project.
-                    self._parent: {
-                        'type': 'join',
-                        'relations': {
-                            self._parent: self._type
-                        }
-                    },
                     'progetto': {'type': 'keyword'},
                     'publisher': {'type': 'keyword'},
                 }
@@ -302,7 +295,7 @@ class PageIndex(Index):
     def extract_document(self, data):
         doc = {}
 
-        attrs = ('project', 'title', 'headers', 'version', 'path',
+        attrs = ('id', 'project', 'title', 'headers', 'version', 'path',
                  'content', 'taxonomy', 'commit', 'progetto', 'publisher')
         for attr in attrs:
             doc[attr] = data.get(attr, '')
@@ -349,13 +342,6 @@ class SectionIndex(Index):
                     },
                     # Add a weight field to enhance relevancy scoring.
                     'weight': {'type': 'float'},
-                    # Associate a section with a page.
-                    self._parent: {
-                        'type': 'join',
-                        'relations': {
-                            self._parent: self._type
-                        }
-                    },
                 }
             }
         }


### PR DESCRIPTION
So that provisioning work and reindexing work on top of empty
indices.
This reverts yet another bit of 597421d by adding back the id
for the page. Then reverts c79c6da3a692a4069dd9ab720d915e358ebba3bf
which added a join relations between two different indexes than
ES does not like.