### PR TITLE
Adds a command to clean es index

### DIFF
--- a/readthedocs/docsitalia/management/commands/clean_es_index.py
+++ b/readthedocs/docsitalia/management/commands/clean_es_index.py
@@ -1,0 +1,49 @@
+"""Removes projects without publisher from the ES index"""
+from __future__ import (
+    absolute_import, print_function)
+
+from django.db.models import Q
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+from elasticsearch import Elasticsearch
+from elasticsearch.exceptions import NotFoundError
+from readthedocs.projects.models import Project
+
+from readthedocs.docsitalia.models import PublisherProject
+
+
+class Command(BaseCommand):
+
+    """
+    Clean ES index:
+
+    Removes projects without publisher or inactive publisher or
+    inactive publisher project from the ES index.
+    Delete projects not linked to a publisher project from the db.
+    """
+
+    def handle(self, *args, **options):
+        """handle command"""
+        e_s = Elasticsearch(settings.ES_HOSTS)
+        inactive_pp = PublisherProject.objects.filter(
+            Q(active=False) | Q(publisher__active=False)
+        ).values_list('pk', flat=True)
+        queryset = Project.objects.filter(
+            Q(publisherproject__isnull=True) | Q(publisherproject__in=inactive_pp)
+        )
+        for p_o in queryset:
+            print(p_o.name, p_o.get_absolute_url(), p_o.pk)
+            try:
+                e_s.delete(index='readthedocs', doc_type='project', id=p_o.pk)
+            except NotFoundError:
+                print('Index not found')
+            try:
+                e_s.delete_by_query(
+                    index='readthedocs', doc_type='page',
+                    body={'query': {'term': {'project_id': p_o.pk}}}
+                )
+            except NotFoundError:
+                print('Index not found')
+            print('')
+        Project.objects.filter(publisherproject__isnull=True).delete()

--- a/readthedocs/rtd_tests/tests/test_docsitalia.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia.py
@@ -8,6 +8,7 @@ from mock import patch
 import pytest
 
 from django import forms
+from django.core.management import call_command
 from django.conf import settings
 from django.test import TestCase, RequestFactory
 from django.core.urlresolvers import reverse
@@ -1001,3 +1002,104 @@ class DocsItaliaTest(TestCase):
                 text=PROJECTS_METADATA)
             publisher = form.save()
         self.assertTrue(publisher.pk)
+
+    def test_clean_es_index_no_publisher_linked(self):
+        publisher = Publisher.objects.create(
+            name='Test Org',
+            slug='testorg',
+            metadata={},
+            projects_metadata={},
+            active=True
+        )
+        pub_project = PublisherProject.objects.create(
+            name='Test Project',
+            slug='testproject',
+            metadata={
+                'documents': [
+                    'https://github.com/testorg/myrepourl',
+                    'https://github.com/testorg/anotherrepourl',
+                ]
+            },
+            publisher=publisher,
+            active=True
+        )
+        project = Project.objects.create(
+            name='my project',
+            slug='myprojectslug',
+            repo='https://github.com/testorg/myrepourl.git'
+        )
+        second_project = Project.objects.create(
+            name='my second project',
+            slug='mysecondprojectslug',
+            repo='https://github.com/testorg/mysecondrepourl.git'
+        )
+        pub_project.projects.add(second_project)
+        with patch('elasticsearch.Elasticsearch.delete') as d, patch('elasticsearch.Elasticsearch.delete_by_query') as f :
+            d.return_value = True
+            call_command('clean_es_index')
+            self.assertNotIn(second_project.pk, [e[1]['id'] for e in d.call_args_list])
+            self.assertIn(project.pk, [e[1]['id'] for e in d.call_args_list])
+        self.assertEqual(Project.objects.all().count(), 1)
+        self.assertTrue(Project.objects.filter(slug='mysecondprojectslug').exists())
+
+    def test_clean_es_index_inactive_publisher_project(self):
+        publisher = Publisher.objects.create(
+            name='Test Org',
+            slug='testorg',
+            metadata={},
+            projects_metadata={},
+            active=False
+        )
+        pub_project = PublisherProject.objects.create(
+            name='Test Project',
+            slug='testproject',
+            metadata={
+                'documents': [
+                    'https://github.com/testorg/myrepourl',
+                    'https://github.com/testorg/anotherrepourl',
+                ]
+            },
+            publisher=publisher,
+            active=True
+        )
+        project = Project.objects.create(
+            name='my project',
+            slug='myprojectslug',
+            repo='https://github.com/testorg/myrepourl.git'
+        )
+        pub_project.projects.add(project)
+        with patch('elasticsearch.Elasticsearch.delete') as d, patch('elasticsearch.Elasticsearch.delete_by_query') as f :
+            d.return_value = True
+            call_command('clean_es_index')
+            self.assertIn(project.pk, [e[1]['id'] for e in d.call_args_list])
+
+    def test_clean_es_index_inactive_publisher(self):
+        publisher = Publisher.objects.create(
+            name='Test Org',
+            slug='testorg',
+            metadata={},
+            projects_metadata={},
+            active=True
+        )
+        pub_project = PublisherProject.objects.create(
+            name='Test Project',
+            slug='testproject',
+            metadata={
+                'documents': [
+                    'https://github.com/testorg/myrepourl',
+                    'https://github.com/testorg/anotherrepourl',
+                ]
+            },
+            publisher=publisher,
+            active=False
+        )
+        project = Project.objects.create(
+            name='my project',
+            slug='myprojectslug',
+            repo='https://github.com/testorg/myrepourl.git'
+        )
+        pub_project.projects.add(project)
+        with patch('elasticsearch.Elasticsearch.delete') as d,  patch('elasticsearch.Elasticsearch.delete_by_query') as f :
+            d.return_value = True
+            call_command('clean_es_index')
+            self.assertIn(project.pk, [e[1]['id'] for e in d.call_args_list])


### PR DESCRIPTION
Clean ES index:
Removes projects and pages without publisher or inactive publisher or inactive publisher project from the ES index.
Delete projects not linked to a publisher project from the db.