### PR TITLE
projects: don't explode trying to update UpdateDocsTaskStep state

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -265,6 +265,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
         if config is not None:
             self.config = config
         self.task = task
+        self.setup_env = None
 
     def _log(self, msg):
         log.info(LOG_TEMPLATE
@@ -327,12 +328,13 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
                 'An unhandled exception was raised during build setup',
                 extra={'tags': {'build': build_pk}}
             )
-            self.setup_env.failure = BuildEnvironmentError(
-                BuildEnvironmentError.GENERIC_WITH_BUILD_ID.format(
-                    build_id=build_pk,
+            if self.setup_env is not None:
+                self.setup_env.failure = BuildEnvironmentError(
+                    BuildEnvironmentError.GENERIC_WITH_BUILD_ID.format(
+                        build_id=build_pk,
+                    )
                 )
-            )
-            self.setup_env.update_build(BUILD_STATE_FINISHED)
+                self.setup_env.update_build(BUILD_STATE_FINISHED)
             return False
         else:
             # No exceptions in the setup step, catch unhandled errors in the


### PR DESCRIPTION
If we don't have it.

```
Traceback (most recent call last):
  File "/readthedocs/projects/tasks.py", line 313, in run
    self.version = self.get_version(self.project, version_pk)
  File "/readthedocs/projects/tasks.py", line 84, in get_version
    version_data = api_v2.version(version_pk).get()
  File "/lib/python3.5/site-packages/slumber/__init__.py", line 155, in get
    resp = self._request("GET", params=kwargs)
  File "/lib/python3.5/site-packages/slumber/__init__.py", line 101, in _request
    raise exception_class("Client Error %s: %s" % (resp.status_code, url), response=resp, content=resp.content)
slumber.exceptions.HttpNotFoundError: Client Error 404: http://localhost:8002/api/v2/version/868/

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/docsitalia/management/commands/rebuild_projects.py", line 33, in handle
    task.run(version.project.pk, version_pk=version.pk, build_pk=build.pk)
  File "/readthedocs/projects/tasks.py", line 332, in run
    build_id=build_pk,
AttributeError: 'UpdateDocsTaskStep' object has no attribute 'setup_env'
```

Refs #107