### PR TITLE
docsitalia: don't leak the Project on metadata import error

### DIFF
--- a/readthedocs/docsitalia/views/core_views.py
+++ b/readthedocs/docsitalia/views/core_views.py
@@ -124,11 +124,13 @@ class DocsItaliaImport(ImportView):  # pylint: disable=too-many-ancestors
         except InvalidMetadata as exception:
             log.error('Failed to import document invalid metadata %s', exception)
             msg = _('Invalid document_settings.yml found in the repository')
+            project.delete()
             return render(request, 'docsitalia/import_error.html', {'error_msg': msg})
         except Exception as e: # noqa
             log.error(
                 'Failed to import document metadata: %s', e)
             msg = _('Failed to download document_settings.yml from the repository')
+            project.delete()
             return render(request, 'docsitalia/import_error.html', {'error_msg': msg})
 
         extra_fields = ProjectExtraForm.Meta.fields

--- a/readthedocs/rtd_tests/tests/test_docsitalia_views.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia_views.py
@@ -331,6 +331,9 @@ class DocsItaliaViewsTest(TestCase):
             response = self.client.post(
                 '/docsitalia/dashboard/import/', data=self.import_project_data)
         self.assertTemplateUsed(response, 'docsitalia/import_error.html')
+        project_name = self.import_project_data['name']
+        project = Project.objects.filter(name=project_name)
+        self.assertFalse(project.exists())
 
     def test_docsitalia_import_render_error_with_invalid_metadata(self):
         self.client.login(username='eric', password='test')
@@ -339,6 +342,9 @@ class DocsItaliaViewsTest(TestCase):
             response = self.client.post(
                 '/docsitalia/dashboard/import/', data=self.import_project_data)
         self.assertTemplateUsed(response, 'docsitalia/import_error.html')
+        project_name = self.import_project_data['name']
+        project = Project.objects.filter(name=project_name)
+        self.assertFalse(project.exists())
 
     @mock.patch('readthedocs.docsitalia.views.core_views.trigger_build')
     def test_docsitalia_redirect_to_project_detail_with_valid_metadata(self, trigger_build):


### PR DESCRIPTION
When import a new document if we fail to parse or download the
metadata we have to remove the newly create Project instance.