### PR TITLE
refactor the project import machinery

### DIFF
--- a/readthedocs/docsitalia/signals.py
+++ b/readthedocs/docsitalia/signals.py
@@ -10,51 +10,12 @@ from django.db.models.signals import pre_delete
 
 from readthedocs.core.signals import webhook_github
 from readthedocs.doc_builder.signals import finalize_sphinx_context_data
-from readthedocs.oauth.models import RemoteRepository
-from readthedocs.projects.signals import project_import
 
 from .github import get_metadata_for_document
 from .models import PublisherProject, update_project_from_metadata
 
 
 log = logging.getLogger(__name__) # noqa
-
-
-@receiver(project_import)
-def on_project_import(sender, **kwargs): # noqa
-    """
-    Main entry point for Project related customizations
-
-    After a Project is imported we need to do a couple of things, hooking
-    to this signal permits us to avoid messing with RTD code.
-    First we connect a Project to its PublisherProject, and that's the
-    easy part.
-    Then we need to update the Project model with the data we have in the
-    document_settings.yml. We don't care much about what it's in the model
-    and we consider the config file as source of truth.
-    """
-
-    project = sender
-
-    try:
-        remote = RemoteRepository.objects.get(project=project)
-    except RemoteRepository.DoesNotExist:
-        log.error('Missing RemoteRepository for project {}'.format(project))
-    else:
-        pub_projects = PublisherProject.objects.filter(
-            metadata__documents__contains=[{'repo_url': remote.html_url}]
-        )
-        for pub_proj in pub_projects:
-            pub_proj.projects.add(project)
-
-    try:
-        # we take the file via http because we don't have a checkout
-        metadata = get_metadata_for_document(project)
-    except Exception as e:  # noqa
-        log.error(
-            'Failed to import document metadata: %s', e)
-    else:
-        update_project_from_metadata(project, metadata)
 
 
 @receiver(webhook_github)

--- a/readthedocs/rtd_tests/tests/test_docsitalia.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia.py
@@ -874,7 +874,7 @@ class DocsItaliaTest(TestCase):
                 exc=IOError)
             self.assertFalse(form.is_valid())
 
-    def test_publisher_admin_form_errors_without_projects_settings(self):
+    def test_publisher_admin_form_errors_with_invalid_metadata(self):
         data = {
             'name': 'testorg',
             'slug': 'testorg',

--- a/readthedocs/rtd_tests/tests/test_docsitalia.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia.py
@@ -22,7 +22,6 @@ from readthedocs.core.signals import webhook_github
 from readthedocs.docsitalia.resolver import ItaliaResolver
 from readthedocs.oauth.models import RemoteOrganization, RemoteRepository
 from readthedocs.projects.models import Project
-from readthedocs.projects.signals import project_import
 
 from readthedocs.docsitalia.forms import PublisherAdminForm
 from readthedocs.docsitalia.github import InvalidMetadata
@@ -230,95 +229,6 @@ class DocsItaliaTest(TestCase):
 
         remote_repos = RemoteRepository.objects.all()
         self.assertEqual(remote_repos.count(), 1)
-
-    @patch('django.contrib.messages.api.add_message')
-    def test_project_import_signal_works(self, add_message):
-        publisher = Publisher.objects.create(
-            name='Test Org',
-            slug='testorg',
-            metadata={},
-            projects_metadata={},
-            active=True
-        )
-
-        pub_project = PublisherProject.objects.create(
-            name='Test Project',
-            slug='testproject',
-            metadata={
-                'documents': [
-                    {
-                        'title': 'a title',
-                        'repository': 'myrepourl',
-                        'repo_url': 'https://github.com/testorg/myrepourl'
-                    }, {
-                        'title': 'another title',
-                        'repository': 'anotherrepourl',
-                        'repo_url': 'https://github.com/testorg/anotherrepourl'
-                    },
-                ]
-            },
-            publisher=publisher,
-            active=True
-        )
-
-        project = Project.objects.create(
-            name='my project',
-            slug='myprojectslug',
-            repo='https://github.com/testorg/myrepourl.git'
-        )
-        remote = RemoteRepository.objects.create(
-            full_name='remote repo name',
-            html_url='https://github.com/testorg/myrepourl',
-            project=project,
-        )
-        request = self.factory.get('/')
-        request.user = self.user
-        with requests_mock.Mocker() as rm:
-            rm.get(
-                'https://raw.githubusercontent.com/testorg/'
-                'myrepourl/master/document_settings.yml',
-                text='')
-            project_import.send(sender=project, request=request)
-
-        project_for_pub_project = pub_project.projects.filter(pk=project.pk)
-        self.assertTrue(project_for_pub_project.exists())
-        self.assertEqual(pub_project.projects.count(), 1)
-
-        other_project = Project.objects.create(
-            name='my other project',
-            slug='myotherprojectslug',
-            repo='https://github.com/testorg/myotherproject.git'
-        )
-        with requests_mock.Mocker() as rm:
-            rm.get(
-                'https://raw.githubusercontent.com/testorg/'
-                'myotherproject/master/document_settings.yml',
-                text='')
-        project_import.send(sender=other_project, request=request)
-
-        self.assertEqual(pub_project.projects.count(), 1)
-
-    @patch('django.contrib.messages.api.add_message')
-    def test_project_import_parse_document_metadata_correctly(self, add_message):
-        project = Project.objects.create(
-            name='my project',
-            slug='myprojectslug',
-            description='mydescription',
-            repo='https://github.com/testorg/myrepourl.git'
-        )
-        request = self.factory.get('/')
-        request.user = self.user
-        with requests_mock.Mocker() as rm:
-            rm.get(
-                'https://raw.githubusercontent.com/testorg/'
-                'myrepourl/master/document_settings.yml',
-                text=DOCUMENT_METADATA)
-            project_import.send(sender=project, request=request)
-        project.refresh_from_db()
-        self.assertEqual(project.name, 'Documento Documentato Pubblicamente')
-        self.assertEqual(project.description, 'Lorem ipsum dolor sit amet, consectetur\n')
-        self.assertEqual(project.tags.count(), 1)
-        self.assertIn('amazing-document', project.tags.slugs())
 
     @patch('django.contrib.messages.api.add_message')
     @override_settings(PUBLIC_PROTO='http', PUBLIC_DOMAIN='readthedocs.org')

--- a/readthedocs/rtd_tests/tests/test_docsitalia_views.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia_views.py
@@ -34,7 +34,7 @@ class DocsItaliaViewsTest(TestCase):
         eric = User.objects.get(username='eric')
         remote = RemoteRepository.objects.create(
             full_name='remote repo name',
-            html_url='https://github.com/testorg/myrepourl',
+            html_url='https://github.com/org-docs-italia/altro-progetto',
             ssh_url='https://github.com/org-docs-italia/altro-progetto.git',
         )
         remote.users.add(eric)
@@ -341,7 +341,7 @@ class DocsItaliaViewsTest(TestCase):
         self.assertTemplateUsed(response, 'docsitalia/import_error.html')
 
     @mock.patch('readthedocs.docsitalia.views.core_views.trigger_build')
-    def test_docsitalia_redirect_to_project_detail_with_valid_metadata(self, trigger_build):
+    def test_docsitalia_import_redirect_to_project_detail_with_valid_metadata(self, trigger_build):
         self.client.login(username='eric', password='test')
         with requests_mock.Mocker() as rm:
             rm.get(self.document_settings_url, text=DOCUMENT_METADATA)
@@ -352,6 +352,48 @@ class DocsItaliaViewsTest(TestCase):
         self.assertEqual(repo.project, project)
         redirect_url = reverse('projects_detail', kwargs={'project_slug': 'altro-progetto'})
         self.assertRedirects(response, redirect_url)
+
+    @mock.patch('readthedocs.docsitalia.views.core_views.trigger_build')
+    def test_docsitalia_import_update_project_with_valid_metadata(self, trigger_build):
+        self.client.login(username='eric', password='test')
+        with requests_mock.Mocker() as rm:
+            rm.get(self.document_settings_url, text=DOCUMENT_METADATA)
+            response = self.client.post(
+                '/docsitalia/dashboard/import/', data=self.import_project_data)
+        project = Project.objects.get(repo=self.import_project_data['repo'])
+        self.assertEqual(project.name, 'Documento Documentato Pubblicamente')
+        self.assertEqual(project.description, 'Lorem ipsum dolor sit amet, consectetur\n')
+        project_tags = list(project.tags.slugs())
+        self.assertEqual(project_tags, ['amazing-document'])
+        self.assertEqual(project.language, 'it')
+
+    @mock.patch('readthedocs.docsitalia.views.core_views.trigger_build')
+    def test_docsitalia_import_connect_project_with_publisher_project(self, trigger_build):
+        publisher = Publisher.objects.create(
+            name='Test Org',
+            slug='testorg',
+            metadata={},
+            projects_metadata={},
+            active=True
+        )
+        pub_project = PublisherProject.objects.create(
+            name='Test Project',
+            slug='testproject',
+            metadata={
+                'documents': [{
+                    'repo_url': 'https://github.com/org-docs-italia/altro-progetto'
+                }]
+            },
+            publisher=publisher,
+            active=True
+        )
+
+        self.client.login(username='eric', password='test')
+        with requests_mock.Mocker() as rm:
+            rm.get(self.document_settings_url, text=DOCUMENT_METADATA)
+            response = self.client.post(
+                '/docsitalia/dashboard/import/', data=self.import_project_data)
+        self.assertEqual(pub_project.projects.count(), 1)
 
     @mock.patch('readthedocs.docsitalia.views.core_views.trigger_build')
     def test_docsitalia_import_render_error_for_invalid_fields(self, trigger_build):


### PR DESCRIPTION
Do our own things one time in the view instead of doing some work twice both in the view and and the signal handlers.