### PR TITLE
Shows only documents with successful builds

### DIFF
--- a/readthedocs/core/management/commands/reindex_elasticsearch.py
+++ b/readthedocs/core/management/commands/reindex_elasticsearch.py
@@ -12,8 +12,10 @@ from django.core.management.base import BaseCommand, CommandError
 from readthedocs.builds.constants import LATEST
 from readthedocs.builds.models import Version
 from readthedocs.docsitalia.models import PublisherProject
+from readthedocs.docsitalia.utils import get_projects_with_builds
 from readthedocs.projects.models import Project
 from readthedocs.projects.tasks import update_search
+
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +45,7 @@ class Command(BaseCommand):
             active=True,
             publisher__active=True
         ).values_list('pk', flat=True)
-        projects = Project.objects.filter(
+        projects = get_projects_with_builds().filter(
             publisherproject__in=publisher_projects
         ).values_list('pk', flat=True)
         queryset = Version.objects.filter(

--- a/readthedocs/docsitalia/models.py
+++ b/readthedocs/docsitalia/models.py
@@ -16,6 +16,8 @@ from readthedocs.oauth.models import RemoteOrganization, RemoteRepository
 
 from readthedocs.core.resolver import resolver
 
+from .utils import get_projects_with_builds
+
 
 def update_project_from_metadata(project, metadata):
     """Update a project instance with the validated  project metadata"""
@@ -216,16 +218,10 @@ class PublisherProject(models.Model):
 
     def active_documents(self):
         """Active documents"""
-        with_public_version = Version.objects.filter(
-            privacy_level='public',
-            active=True,
-        ).values_list(
-            'project',
-            flat=True
+        builded_projects = get_projects_with_builds().filter(
+            publisherproject=self
         )
-        return self.projects.filter(
-            pk__in=with_public_version
-        ).order_by(
+        return builded_projects.order_by(
             '-modified_date', '-pub_date'
         )
 

--- a/readthedocs/templates/docsitalia/publisherproject_detail.html
+++ b/readthedocs/templates/docsitalia/publisherproject_detail.html
@@ -13,7 +13,7 @@ associati
     <h1 class="mb-4">{{ object }}</h1>
     <h2 class="mb-4 font-weight-normal">Tutti i documenti che fanno parte del progetto {{ object }}</h2>
     <div class="row">
-      {% for project in object.projects.all %}
+      {% for project in object.active_documents %}
       {% include 'docsitalia/includes/document_card.html' %}
       {% endfor %}
     </div>


### PR DESCRIPTION
Fix for Issue: https://github.com/italia/docs.italia.it/issues/167

After merge we need to run the `clear es index` management command to delete the unwanted documents from ES