### PR TITLE
Update doctools.js from sphinx

### DIFF
--- a/media/javascript/doctools.js
+++ b/media/javascript/doctools.js
@@ -91,6 +91,30 @@ jQuery.fn.highlightText = function(text, className) {
   });
 };
 
+/*
+ * backward compatibility for jQuery.browser
+ * This will be supported until firefox bug is fixed.
+ */
+if (!jQuery.browser) {
+  jQuery.uaMatch = function(ua) {
+    ua = ua.toLowerCase();
+
+    var match = /(chrome)[ \/]([\w.]+)/.exec(ua) ||
+      /(webkit)[ \/]([\w.]+)/.exec(ua) ||
+      /(opera)(?:.*version|)[ \/]([\w.]+)/.exec(ua) ||
+      /(msie) ([\w.]+)/.exec(ua) ||
+      ua.indexOf("compatible") < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec(ua) ||
+      [];
+
+    return {
+      browser: match[ 1 ] || "",
+      version: match[ 2 ] || "0"
+    };
+  };
+  jQuery.browser = {};
+  jQuery.browser[jQuery.uaMatch(navigator.userAgent).browser] = true;
+}
+
 /**
  * Small JavaScript module for the documentation.
  */
@@ -152,6 +176,7 @@ var Documentation = {
 
   /**
    * workaround a firefox stupidity
+   * see: https://bugzilla.mozilla.org/show_bug.cgi?id=645075
    */
   fixFirefoxAnchorBug : function() {
     if (document.location.hash && $.browser.mozilla)


### PR DESCRIPTION
Since the doctools.js file included with readthedocs is quite old, the
version of jQuery included with the new theme is causing the bug
described in https://github.com/sphinx-doc/sphinx/issues/3549.
This commit introduce a compatibility shim taken from the new version
of doctools.js.
See: https://github.com/sphinx-doc/sphinx/commit/c608af4babe140626877be08535af095ff633c00#diff-d7b634f9b44ce8b7a4e91a87f1a2a136