### PR TITLE
Add triple quotes to prevent pdflatex to fail conversion

### DIFF
--- a/readthedocs/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/templates/doc_builder/conf.py.tmpl
@@ -47,12 +47,21 @@ html_theme_path = [docs_italia_theme.get_html_theme_path()]
 
 # docs_italia_theme default options
 source_suffix = SUFFIX
-html_title = u'{{ project.name }}'
+{% autoescape off %}
+html_title = u"""{{ project.name }}"""
+{% endautoescape %}
 html_use_index = False
 numfig = True
 latex_documents = [
-  ('index', '{{ project.slug }}.tex', u'{{ project.name }}',
-   u'{{ publisher.name }}', 'manual'),
+  (
+    'index',
+    '{{ project.slug }}.tex',
+    {% autoescape off %}
+    u"""{{ project.name }}""",
+    u"""{{ publisher.name }}""",
+    {% endautoescape %}
+    'manual'
+  ),
 ]
 latex_show_urls = 'footnote'
 latex_show_pagerefs = True


### PR DESCRIPTION
Fix this https://github.com/italia/docs.italia.it/issues/138
Turns off the django auto escape filter in the conf template and adds triple quotes to strings