### PR TITLE
Read documents_settings in the root of the document

### DIFF
--- a/readthedocs/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/templates/doc_builder/conf.py.tmpl
@@ -145,12 +145,14 @@ context['subproject_data'] = [
     },
     {% endfor %}
 ]
-try:
-    with open('document_settings.yml') as rtd:
-        data = rtd.read()
-        data = yaml.safe_load(data)
-except:
-    data = {}
+{% comment %}
+We remove the try except if the document_settings.yml file is not
+found so that we have a more understandable exception during the build process.
+{% endcomment %}
+document_settings_path = os.path.join('{{ version.get_build_path }}', 'document_settings.yml')
+with open(document_settings_path) as rtd:
+    data = rtd.read()
+    data = yaml.safe_load(data)
 context['docsitalia_data'] = data
 
 if 'html_context' in globals():


### PR DESCRIPTION
https://github.com/italia/docs.italia.it/issues/183

We need to read the document settings at the root of the project.

I also removed the try except since we want to block the build if it doesn' t find  the document_settings and the log on RTD is more clear