### PR TITLE
Temporary fix for broken static files in subdirectories

### DIFF
--- a/readthedocs/docsitalia/templatetags/docs_italia.py
+++ b/readthedocs/docsitalia/templatetags/docs_italia.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 from django import template
+from readthedocs.core.resolver import resolve
 
 from ..models import PublisherProject
 
@@ -15,3 +16,14 @@ def get_publisher_project(slug):
         return PublisherProject.objects.get(slug=slug)
     except PublisherProject.DoesNotExist:
         return None
+
+
+@register.simple_tag(name="doc_url_patched")
+def make_document_url(project, version=None, page=''):
+    """create the full document URL and appends index.html if root"""
+    if not project:
+        return ""
+    url = resolve(project=project, version_slug=version, filename=page)
+    if url.endswith('/'):
+        url = '%sindex.html' % url
+    return url

--- a/readthedocs/templates/docsitalia/overrides/search/elastic_search.html
+++ b/readthedocs/templates/docsitalia/overrides/search/elastic_search.html
@@ -1,6 +1,6 @@
 {% extends "projects/base_project.html" %}
 
-{% load core_tags i18n  docs_italia %}
+{% load core_tags docs_italia i18n %}
 
 {% block title %}{% blocktrans with query=query|default:"" %}Search: {{ query }} {% endblocktrans %}{% endblock %}
 
@@ -150,7 +150,7 @@
                 {% if result.fields.name %}
                   {# Project #}
                   <h3 class="document-card-title color-inherit">
-                    <a href="{% doc_url result.fields.slug|get_project %}">{{ result.fields.name }}</a>
+                    <a href="{% doc_url_patched result.fields.slug|get_project %}">{{ result.fields.name }}</a>
                   </h3>
                   <div class="document-card-description color-inherit">
                     {% for fragment in result.highlight.description|slice:":1" %}
@@ -164,7 +164,7 @@
                   {# File #}
                   <h3 class="document-card-title color-inherit">
                     {% with result.fields.project|get_project as proj %}
-                    <a href="{% doc_url proj result.fields.version result.fields.path %}?highlight={{ query }}">{{ proj }} - {{ result.fields.title|safe }}</a>
+                    <a href="{% doc_url_patched proj result.fields.version result.fields.path %}?highlight={{ query }}">{{ proj }} - {{ result.fields.title|safe }}</a>
                     {% endwith %}
                   </h3>
                   <div class="document-card-description color-inherit">


### PR DESCRIPTION
This is just a temporary fix for search results page: when accessing documents in subdirectories without filename, the theme breaks. This is likely due to an error in nginx regexps, but this provides a first fixes
This needs to be reverted once the nginx configuration is fixed

See https://docs-italia-staging.teamdigitale.it/search/?q=daf&type=file