### PR TITLE
Support markdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - source ~/.nvm/nvm.sh
   - nvm install --lts
   - nvm use --lts
-  - npm install -g bower gulp
+  - npm install -g bower gulp@^3.x
   - npm install
   - bower install
 script:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-config-airbnb-base": "^11.2.0",
     "eslint-plugin-import": "^2.2.0",
     "event-stream": "^3.3.1",
-    "gulp": "*",
+    "gulp": "^3.x",
     "gulp-eslint": "^3.0.1",
     "gulp-less": "^3.0.3",
     "gulp-rename": "^1.2.2",

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -81,7 +81,7 @@ class BaseMkdocs(BaseBuilder):
         # Handle custom docs dirs
         user_docs_dir = user_config.get('docs_dir')
         docs_dir = self.docs_dir(docs_dir=user_docs_dir)
-        self.create_index(extension='md')
+        self.create_index(extensions=['md'])
         user_config['docs_dir'] = docs_dir
 
         # Set mkdocs config values

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -147,7 +147,7 @@ class BaseSphinx(BaseBuilder):
         try:
             self.version.get_conf_py_path()
         except ProjectConfigurationError:
-            master_doc = self.create_index(extension='rst')
+            master_doc = self.create_index(extensions=['rst', 'md'])
             self._write_config(master_doc=master_doc)
 
         try:

--- a/readthedocs/doc_builder/base.py
+++ b/readthedocs/doc_builder/base.py
@@ -90,7 +90,7 @@ class BaseBuilder(object):
     def create_index(self, extensions=None, **__):
         """Create an index file if it needs it."""
         if extensions is None:
-            extensions = []
+            extensions = ['rst']
         docs_dir = self.docs_dir()
 
         for ext in extensions:

--- a/readthedocs/doc_builder/base.py
+++ b/readthedocs/doc_builder/base.py
@@ -87,8 +87,10 @@ class BaseBuilder(object):
             docs_dir = checkout_path
         return docs_dir
 
-    def create_index(self, extensions=['rst', 'md'], **__):
+    def create_index(self, extensions=None, **__):
         """Create an index file if it needs it."""
+        if extensions is None:
+            extensions = []
         docs_dir = self.docs_dir()
 
         for ext in extensions:

--- a/readthedocs/doc_builder/base.py
+++ b/readthedocs/doc_builder/base.py
@@ -118,7 +118,7 @@ Check out our `Getting Started Guide
 familiar with Read the Docs.
                 """
 
-            index_file.write(index_text.format(dir=docs_dir, ext=extension[0]))
+            index_file.write(index_text.format(dir=docs_dir, ext=extensions[0]))
             index_file.close()
         return 'index'
 

--- a/readthedocs/doc_builder/base.py
+++ b/readthedocs/doc_builder/base.py
@@ -87,20 +87,20 @@ class BaseBuilder(object):
             docs_dir = checkout_path
         return docs_dir
 
-    def create_index(self, extension='md', **__):
+    def create_index(self, extensions=['rst', 'md'], **__):
         """Create an index file if it needs it."""
         docs_dir = self.docs_dir()
 
-        index_filename = os.path.join(
-            docs_dir, 'index.{ext}'.format(ext=extension))
+        for ext in extensions:
+            index_filename = os.path.join(
+                docs_dir, 'index.{ext}'.format(ext=ext))
+            if os.path.exists(index_filename):
+                break
         if not os.path.exists(index_filename):
-            readme_filename = os.path.join(
-                docs_dir, 'README.{ext}'.format(ext=extension))
-            if os.path.exists(readme_filename):
-                return 'README'
-            else:
-                index_file = open(index_filename, 'w+')
-                index_text = """
+            index_filename = os.path.join(
+                docs_dir, 'index.{ext}'.format(ext=extensions[0]))
+            index_file = open(index_filename, 'w+')
+            index_text = """
 
 Welcome to Read the Docs
 ------------------------
@@ -116,8 +116,8 @@ Check out our `Getting Started Guide
 familiar with Read the Docs.
                 """
 
-                index_file.write(index_text.format(dir=docs_dir, ext=extension))
-                index_file.close()
+            index_file.write(index_text.format(dir=docs_dir, ext=extension[0]))
+            index_file.close()
         return 'index'
 
     def run(self, *args, **kwargs):

--- a/readthedocs/rtd_tests/files/conf.py
+++ b/readthedocs/rtd_tests/files/conf.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 extensions = []
 templates_path = ['/tmp/sphinx-template-dir', 'templates', '_templates', '.templates']
-source_suffix = ['.rst']
+source_suffix = ['.rst', '.md']
 master_doc = 'index'
 project = u'Pip'
 copyright = str(datetime.now().year)

--- a/readthedocs/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/templates/doc_builder/conf.py.tmpl
@@ -18,8 +18,12 @@ import sys
 import os.path
 import yaml
 import docs_italia_theme
+import recommonmark
 from six import string_types
 from sphinx import version_info
+from recommonmark.parser import CommonMarkParser
+from recommonmark.transform import AutoStructify
+
 
 # Get suffix for proper linking to GitHub
 # This is deprecated in Sphinx 1.3+,
@@ -32,12 +36,22 @@ if globals().get('source_suffix', False):
 else:
     SUFFIX = '.rst'
 
+# Support markdown
+def setup(app):
+    app.add_source_parser('.md', CommonMarkParser)
+    app.add_config_value('recommonmark_config', {
+            'enable_eval_rst': True
+        }, True)
+    app.add_transform(AutoStructify)
+
+exclude_patterns = ['readme.md', 'README.md']
+
 # Add RTD Static Path. Add to the end because it overwrites previous files.
 if not 'html_static_path' in globals():
     html_static_path = []
 if os.path.exists('_static'):
     html_static_path.append('_static')
-html_static_path.append('{{ static_path }}')
+#html_static_path.append('{{ static_path }}')
 
 # Setting the theme to docs_italia_theme
 html_theme = 'docs_italia_theme'

--- a/readthedocs/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/templates/doc_builder/conf.py.tmpl
@@ -44,7 +44,7 @@ def setup(app):
         }, True)
     app.add_transform(AutoStructify)
 
-exclude_patterns = ['readme.md', 'README.md']
+exclude_patterns = ['readme.md', 'README.md', 'license.md', 'LICENSE.md', 'authors.md', 'AUTHORS.md']
 
 # Add RTD Static Path. Add to the end because it overwrites previous files.
 if not 'html_static_path' in globals():

--- a/readthedocs/templates/sphinx/conf.py.conf
+++ b/readthedocs/templates/sphinx/conf.py.conf
@@ -6,7 +6,7 @@ from datetime import datetime
 
 extensions = []
 templates_path = ['{{ template_dir }}', 'templates', '_templates', '.templates']
-source_suffix = ['.rst']
+source_suffix = ['.rst', '.md']
 master_doc = 'index'
 project = u'{{ project.name }}'
 copyright = str(datetime.now().year)

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ commands =
 
 [testenv:eslint]
 description = run the JavaScript linter (requires gulp installed)
+whitelist_externals = gulp
 commands =
     gulp lint
 


### PR DESCRIPTION
Il supporto per markdown implica:
- aggiunta dell'estensione `md` alla lista `source_suffix` nel `conf.py` di default
- aggiunta di recommonmark e relative opzioni nel `conf.py` aggiunto da Docs Italia
- modifica della funzione che individua il file index in assenza di `conf.py` nel repo