### PR TITLE
Force node 8 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ install:
   - pip install tox-travis
   - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
   - source ~/.nvm/nvm.sh
-  - nvm install --lts
-  - nvm use --lts
+  - nvm install lts/carbon
+  - nvm use lts/carbon
   - npm install -g bower gulp@^3.x
   - npm install
   - bower install


### PR DESCRIPTION
Il codice FE richiede node 8 mentre viene installato node 10 con l'opzione `--lts`

Dal momento che prevediamo di aggiornare a breve con upstream, meglio forzare node 8 nei test