### PR TITLE
Remove noindex from robots.txt since it's deprecated.

### DIFF
--- a/media/robots.txt
+++ b/media/robots.txt
@@ -3,7 +3,3 @@ Disallow: /builds/
 Disallow: /projects/
 Disallow: /profiles/
 Disallow: /sustainability/click/
-Noindex: /builds/
-Noindex: /projects/
-Noindex: /profiles/
-Noindex: /sustainability/click/


### PR DESCRIPTION
Fixes #239 