### PR TITLE
Fix dashboard layout

### DIFF
--- a/readthedocs/projects/static-src/projects/css/_content.less
+++ b/readthedocs/projects/static-src/projects/css/_content.less
@@ -327,3 +327,7 @@ select {
   margin: 4rem 0 2rem;
   border-bottom: 1px solid #D8D8D8;
 }
+
+.project-builds {
+  flex: 1 0 auto;
+}

--- a/readthedocs/projects/static-src/projects/css/_content.less
+++ b/readthedocs/projects/static-src/projects/css/_content.less
@@ -317,3 +317,7 @@ select {
   margin: 4rem 0 2rem;
   border-bottom: 1px solid #D8D8D8;
 }
+
+.project-builds {
+  flex: 1 0 auto;
+}

--- a/readthedocs/projects/static/projects/css/main.css
+++ b/readthedocs/projects/static/projects/css/main.css
@@ -286,6 +286,9 @@ select:hover {
   margin: 4rem 0 2rem;
   border-bottom: 1px solid #D8D8D8;
 }
+.project-builds {
+  flex: 1 0 auto;
+}
 .footer {
   background-color: #00264D;
   color: #FFF;

--- a/readthedocs/projects/static/projects/css/main.css
+++ b/readthedocs/projects/static/projects/css/main.css
@@ -278,6 +278,9 @@ select:hover {
   margin: 4rem 0 2rem;
   border-bottom: 1px solid #D8D8D8;
 }
+.project-builds {
+  flex: 1 0 auto;
+}
 .footer {
   background-color: #00264D;
   color: #FFF;

--- a/readthedocs/templates/docsitalia/overrides/projects/project_dashboard_base.html
+++ b/readthedocs/templates/docsitalia/overrides/projects/project_dashboard_base.html
@@ -57,17 +57,17 @@
           <ul>
             {% for project in project_list %}
             <li class="module-item col-span">
-              <a href="{% url "projects_manage" project.slug %}">
+              <a class="d-flex flex-column flex-md-row justify-content-between" href="{% url "projects_manage" project.slug %}">
               {% block project-name %}
               {{ project.name }}
               {% endblock %}
               {% with builds=project.builds.count %}
               {% if builds == 0 %}
-              <span class="right quiet">
+              <span class="quiet d-flex align-items-center justify-content-end ml-4 mt-3 mt-sm-0 project-builds">
                             {% trans "No builds yet" %}
                           </span>
               {% else %}
-              <span class="right quiet">
+              <span class="quiet d-flex align-items-center justify-content-end ml-4 mt-3 mt-sm-0 project-builds">
                             <span class="build-count">
                               {% blocktrans count counter=builds %}
                                 1 build


### PR DESCRIPTION
Fix #162 

Fixes the layout of the dashboard so that file naming won't overlap build status.

### Desktop view:
![Desktop](https://user-images.githubusercontent.com/27950530/65521907-3b4b1280-deea-11e9-9767-356fe9360f57.png)

### Desktop small view:
![Desktop-small](https://user-images.githubusercontent.com/27950530/65521906-3ab27c00-deea-11e9-830c-e9a04ac7a365.png)

### Tablet view:
![Tablet](https://user-images.githubusercontent.com/27950530/65521905-3ab27c00-deea-11e9-91da-3466e74a6095.png)

### Mobile view:
![Mobile](https://user-images.githubusercontent.com/27950530/65521911-3b4b1280-deea-11e9-9e23-ccd398065e0d.png)

### Mobile small view:
![Mobile-Small](https://user-images.githubusercontent.com/27950530/65521910-3b4b1280-deea-11e9-9b65-7d8dfaa509e8.png)




