### PR TITLE
Redirect on wrong project url segment.

### DIFF
--- a/docker/nginx/sites-available/readthedocs-main.conf
+++ b/docker/nginx/sites-available/readthedocs-main.conf
@@ -59,7 +59,7 @@ server {
 
     # document serving
     location ~* ^/(?P<publisher>[^/]+)/(?P<project>[^/]+)/(?P<document>[^/]+)/ {
-        # first/second submatch redirect to the default language / version by hitting a redirect view on django
+        # first/second/third submatch redirect to the default language / version by hitting a redirect view on django
         location ~* ^/(?P<publisher>[^/]+)/(?P<project>[^/]+)/(?P<document>[^/]+)/$ {
             add_header X-Redirct-From Nginx;
             add_header X-Deity docs;
@@ -70,10 +70,14 @@ server {
             add_header X-Deity docs;
             include /etc/nginx/snippets/fallback_defaults;
         }
-
-        # third submatch serves any project file directly from the local disk. path group is needed to build the
+        location ~* ^/(?P<publisher>[^/]+)/(?P<project>[^/]+)/(?P<document>[^/]+)/(?P<lang>\w\w)/(?P<version>[^/]+)(/?)$ {
+            add_header X-Redirct-From Nginx;
+            add_header X-Deity docs;
+            include /etc/nginx/snippets/fallback_defaults;
+        }
+        # fourth submatch serves any project file directly from the local disk. path group is needed to build the
         # try_files argument because we can't use $uri as we need to remove the prefix up to project
-        location ~* ^/(?P<publisher>[^/]+)/(?P<project>[^/]+)/(?P<document>[^/]+)/(?P<lang>\w\w)/(?P<version>[^/]+)/(?P<path>.*)(/?)$ {
+        location ~* ^/(?P<publisher>[^/]+)/(?P<project>[^/]+)/(?P<document>[^/]+)/(?P<lang>\w\w)/(?P<version>[^/]+)/(?P<path>.+)(/?)$ {
             root /home/documents/public_web_root/;
             try_files /$document/$lang/$version/$path /$document/$lang/$version/$path/index.html /$document/$lang/$version/index.html =404;
         }

--- a/readthedocs/docsitalia/urls.py
+++ b/readthedocs/docsitalia/urls.py
@@ -94,6 +94,14 @@ urlpatterns = [
         DocumentRedirect.as_view(),
         name='document_redirect'
     ),
+    url(
+        (
+            r'^(?P<publisherslug>[-\w]+)/(?P<projectslug>[-\w]+)/(?P<slug>[-\w]+)/'
+            r'(?P<lang>[\w]{2})/(?P<version>[^/]+)(/?)$'
+        ),
+        DocumentRedirect.as_view(),
+        name='document_redirect'
+    ),
 ]
 
 if apps.is_installed('docs_italia_convertitore_web'):

--- a/readthedocs/docsitalia/views/core_views.py
+++ b/readthedocs/docsitalia/views/core_views.py
@@ -122,7 +122,9 @@ class DocumentRedirect(View):
         """Redirect to the canonical URL of the document"""
         try:
             document = self.get_queryset().get(slug=self.kwargs['slug'])
-            return HttpResponseRedirect(document.get_docs_url(lang_slug=self.kwargs.get('lang')))
+            return HttpResponseRedirect(
+                '{}index.html'.format(document.get_docs_url(lang_slug=self.kwargs.get('lang')))
+            )
         except Project.DoesNotExist:
             raise Http404()
 

--- a/readthedocs/rtd_tests/tests/test_docsitalia_views.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia_views.py
@@ -491,14 +491,22 @@ class DocsItaliaViewsTest(TestCase):
         naked_no_build_project_lang_url = '%sit/' % naked_no_build_project_url
 
         response = self.client.get(naked_project_url)
-        self.assertRedirects(response, project.get_canonical_url(), fetch_redirect_response=False)
+        self.assertRedirects(
+            response, '{}index.html'.format(project.get_canonical_url()), fetch_redirect_response=False,
+        )
         response = self.client.get(naked_project_lang_url)
-        self.assertRedirects(response, project.get_canonical_url(), fetch_redirect_response=False)
+        self.assertRedirects(
+            response, '{}index.html'.format(project.get_canonical_url()), fetch_redirect_response=False,
+        )
 
         response = self.client.get(naked_no_build_project_url)
-        self.assertRedirects(response, no_build_project.get_canonical_url(), fetch_redirect_response=False)
+        self.assertRedirects(
+            response, '{}index.html'.format(no_build_project.get_canonical_url()), fetch_redirect_response=False,
+        )
         response = self.client.get(naked_no_build_project_lang_url)
-        self.assertRedirects(response, no_build_project.get_canonical_url(), fetch_redirect_response=False)
+        self.assertRedirects(
+            response, '{}index.html'.format(no_build_project.get_canonical_url()), fetch_redirect_response=False,
+        )
 
         response = self.client.get(naked_privateproject_url)
         self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
Fixes #244 

Essendo l'URL indicato gestito direttamente da nginx i margini di intervento su questa issue sono limitati.
Quello che si può fare (e che viene implementato in questa PR) è fare in modo che tutti i seguenti URL:

https://docs.italia.it/italia/foo/lg-acquisizione-e-riuso-software-per-pa-docs/
https://docs.italia.it/italia/foo/lg-acquisizione-e-riuso-software-per-pa-docs/it/
https://docs.italia.it/italia/foo/lg-acquisizione-e-riuso-software-per-pa-docs/it/bozza/

vengano rediretti a:

https://docs.italia.it/italia/<nome_progetto>/lg-acquisizione-e-riuso-software-per-pa-docs/it/bozza/index.html

La principale limitazione consiste nel fatto che, una volta seguito il redirect, ulteriori modifiche ai segmenti publisher e project ripresentano il medesimo problema (ossia, la pagina viene servita senza redirect); questo avviene a causa del fatto che nginx non ha modo di sapere se quei dati specifici sono o meno presenti nel database, nè abbiamo un tree statico su disco che li contenga (la build genera i file con il nome del documento come identificativo, senza includere in alcun punto publisher e progetto).