### PR TITLE
Refactor docker-compose-tox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ WORKDIR /app
 
 FROM docs_italia_it_base AS docs_italia_it_test
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        wait-for-it \
+    && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -U pip tox
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         git \
         libpq-dev \
+        locales-all \
     && rm -rf /var/lib/apt/lists/*
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1

--- a/docker-compose-tox.yml
+++ b/docker-compose-tox.yml
@@ -9,11 +9,31 @@ services:
     depends_on:
       - db
     environment:
+      # this variable has TRAVIS prefix to be passed from tox to pytest without further tox.ini customization
+      # to reduce the chance of a conflict
       - TRAVIS_DOCSITALIA_DOCKER=1
-    command: tox -e py36,itresolver -- $PYTEST_ARGS
+    command: bash -c "wait-for-it -s -t 300 db:5432 -- tox -e py36 $TOX_ARGS -- --create-db $PYTEST_ARGS"
     volumes:
       - ".:/app:rw"
-      - ".tox:/app/.tox"
+      - tox:/app/.tox
+
+  itresolver:
+    container_name: italia_docs_italia_it_itresolver
+    build:
+      context: .
+      target: docs_italia_it_test
+    image: italia/docs_italia_it_test:latest
+    depends_on:
+      - db
+    environment:
+      # this variable has TRAVIS prefix to be passed from tox to pytest without further tox.ini customization
+      # to reduce the chance of a conflict
+      - TRAVIS_DOCSITALIA_DOCKER=1
+    command: bash -c "wait-for-it -s -t 300 db:5432 -- tox -e itresolver $TOX_ARGS -- --create-db $PYTEST_ARGS"
+    volumes:
+      - ".:/app:rw"
+      - tox:/app/.tox
+
   db:
     image: postgres:10
     environment:

--- a/readthedocs/docsitalia/settings/itresolver_testdocsitalia.py
+++ b/readthedocs/docsitalia/settings/itresolver_testdocsitalia.py
@@ -6,6 +6,18 @@ from .testdocsitalia import DocsItaliaTestSettings
 
 class DocsItaliaItResolverTestSettings(DocsItaliaTestSettings):
 
+    if os.environ.get('TRAVIS_DOCSITALIA_DOCKER', False):
+        DATABASES = {
+            'default': {
+                'ENGINE': 'django.db.backends.postgresql_psycopg2',
+                'USER': 'docs',
+                'HOST': 'db',
+                'PORT': 5432,
+                'PASSWORD': 'docs',
+                'NAME': 'rtd_itresolver'
+            }
+        }
+
     # Override classes
     CLASS_OVERRIDES = {
         'readthedocs.builds.syncers.Syncer': 'readthedocs.builds.syncers.LocalSyncer',


### PR DESCRIPTION
 to split normal and itresolver tests in two different services

use wait-for-it to ensure db is up when tests runs

Testing behavior documented at https://github.com/italia/docs.italia.it/wiki/Eseguire-i-test-con-docker-compose