### PR TITLE
Fix handling of http protocol selection setting

### DIFF
--- a/readthedocs/docsitalia/resolver.py
+++ b/readthedocs/docsitalia/resolver.py
@@ -85,8 +85,8 @@ class ItaliaResolver(ResolverBase):
         :param kwargs: other kwargs
         :return: string
         """
-        protocol = getattr(settings, 'PUBLIC_PROTO', 'https')
-        return super(ItaliaResolver, self).resolve(project, protocol, filename, private, **kwargs)
+        require_https = getattr(settings, 'PUBLIC_DOMAIN_USES_HTTPS', False)
+        return super(ItaliaResolver, self).resolve(project, require_https, filename, private, **kwargs)
 
     @staticmethod
     def resolve_docsitalia(publisher_slug, pb_project_slug=None, protocol='http'):
@@ -98,7 +98,8 @@ class ItaliaResolver(ResolverBase):
         :param protocol: http / https protocol
         """
         domain = getattr(settings, 'PRODUCTION_DOMAIN')
-        protocol = getattr(settings, 'PUBLIC_PROTO', 'https')
+        require_https = getattr(settings, 'PUBLIC_DOMAIN_USES_HTTPS', False)
+        protocol = 'https' if require_https else 'http'
         if pb_project_slug:
             path = u'{}/{}'.format(publisher_slug, pb_project_slug)
         else:

--- a/readthedocs/docsitalia/settings/docker.py
+++ b/readthedocs/docsitalia/settings/docker.py
@@ -22,9 +22,8 @@ class DocsItaliaDockerSettings(CommunityBaseSettings):
     USE_SUBDOMAIN = False
     PUBLIC_DOMAIN = os.environ['PUBLIC_DOMAIN']
     PUBLIC_API_URL = os.environ['PUBLIC_API_URL']
-    PUBLIC_PROTO = os.environ['RTD_PROTO']
     GLOBAL_ANALYTICS_CODE = os.environ['GLOBAL_ANALYTICS_CODE']
-    PUBLIC_DOMAIN_USES_HTTPS = PUBLIC_PROTO == 'https'
+    PUBLIC_DOMAIN_USES_HTTPS = os.environ['RTD_PROTO'] == 'https'
 
     # default build versions
     RTD_LATEST = 'bozza'

--- a/readthedocs/rtd_tests/tests/test_docsitalia.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia.py
@@ -338,7 +338,7 @@ class DocsItaliaTest(TestCase):
         self.assertEqual(remote_repos.count(), 1)
 
     @patch('django.contrib.messages.api.add_message')
-    @override_settings(PUBLIC_PROTO='https', PUBLIC_DOMAIN='readthedocs.org')
+    @override_settings(PUBLIC_DOMAIN_USES_HTTPS=True, PUBLIC_DOMAIN='readthedocs.org')
     def test_project_custom_resolver(self, add_message):
 
         with patch('readthedocs.projects.models.resolve') as resolve_func:
@@ -373,8 +373,9 @@ class DocsItaliaTest(TestCase):
             resolve_func.return_value = ItaliaResolver().resolve(
                 project=project, version_slug=LATEST, language='en', private=False
             )
+            protocol = 'https' if settings.PUBLIC_DOMAIN_USES_HTTPS else 'http'
             self.assertEqual(project.get_docs_url(), '%s://%s/%s/%s/%s/en/%s/' % (
-                settings.PUBLIC_PROTO, settings.PUBLIC_DOMAIN, publisher.slug,
+                protocol, settings.PUBLIC_DOMAIN, publisher.slug,
                 pub_project.slug, project.slug, LATEST
             ))
 
@@ -788,7 +789,7 @@ class DocsItaliaTest(TestCase):
 
     @pytest.mark.skipif(not IT_RESOLVER_IN_SETTINGS, reason='Require CLASS_OVERRIEDS in the settings file to work')
     @pytest.mark.itresolver
-    @override_settings(PUBLIC_PROTO='http', PUBLIC_DOMAIN='readthedocs.org')
+    @override_settings(PUBLIC_DOMAIN_USES_HTTPS=True, PUBLIC_DOMAIN='readthedocs.org')
     def test_projects_by_tag_api_filter_tags(self):
         project = Project.objects.create(
             name='my project',
@@ -837,13 +838,13 @@ class DocsItaliaTest(TestCase):
                   "default_branch": None,
                   "documentation_type": "sphinx",
                   "users": [],
-                  "canonical_url": "http://readthedocs.org/testorg/testproject/myprojectslug/en/latest/",
+                  "canonical_url": "https://readthedocs.org/testorg/testproject/myprojectslug/en/latest/",
                   "publisher": {
-                    "canonical_url": "http://readthedocs.org/testorg",
+                    "canonical_url": "https://readthedocs.org/testorg",
                     "name": "publisher"
                   },
                   "publisher_project": {
-                    "canonical_url": "http://readthedocs.org/testorg/testproject",
+                    "canonical_url": "https://readthedocs.org/testorg/testproject",
                     "name": "Test Project"
                   },
                   "tags": ["ipsum", "lorem"]
@@ -855,7 +856,7 @@ class DocsItaliaTest(TestCase):
 
     @pytest.mark.skipif(not IT_RESOLVER_IN_SETTINGS, reason='Require CLASS_OVERRIEDS in the settings file to work')
     @pytest.mark.itresolver
-    @override_settings(PUBLIC_PROTO='http', PUBLIC_DOMAIN='readthedocs.org')
+    @override_settings(PUBLIC_DOMAIN_USES_HTTPS=True, PUBLIC_DOMAIN='readthedocs.org')
     def test_projects_by_tag_api_filter_publisher(self):
         project = Project.objects.create(
             name='my project',
@@ -916,7 +917,7 @@ class DocsItaliaTest(TestCase):
 
     @pytest.mark.skipif(not IT_RESOLVER_IN_SETTINGS, reason='Require CLASS_OVERRIEDS in the settings file to work')
     @pytest.mark.itresolver
-    @override_settings(PUBLIC_PROTO='http', PUBLIC_DOMAIN='readthedocs.org')
+    @override_settings(PUBLIC_DOMAIN_USES_HTTPS=True, PUBLIC_DOMAIN='readthedocs.org')
     def test_projects_by_tag_api_filter_publisher_project(self):
         project = Project.objects.create(
             name='my project',


### PR DESCRIPTION
PUBLIC_PROTO has been replaced by PUBLIC_DOMAIN_USES_HTTPS to conform to existing codebase

Fix #335 