### PR TITLE
Update date format

### DIFF
--- a/readthedocs/templates/docsitalia/overrides/builds/build_detail.html
+++ b/readthedocs/templates/docsitalia/overrides/builds/build_detail.html
@@ -35,7 +35,7 @@ $(document).ready(function () {
       <div data-bind="visible: finished()">
         <li>
           {% trans "Completed" %}
-          <span>{{ build.date|date:"N j, Y. P" }}</span>
+          <span>{{ build.date|date:"j N Y P" }}</span>
         </li>
 
         <li>

--- a/readthedocs/templates/docsitalia/overrides/builds/build_detail.html
+++ b/readthedocs/templates/docsitalia/overrides/builds/build_detail.html
@@ -35,7 +35,7 @@ $(document).ready(function () {
       <div data-bind="visible: finished()">
         <li>
           {% trans "Completed" %}
-          <span>{{ build.date|date:"j N Y P" }}</span>
+          <span>{{ build.date|date:"j N Y G:i" }}</span>
         </li>
 
         <li>


### PR DESCRIPTION
Fix #330 
Aggiornato il formato data nel template `build_detail.html`
Il nuovo formato si traduce in `Completato 28 Ott. 2019 10:52 a.m.`