### PR TITLE
fix disk watermark exceeded all indices on this node will be marked r…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,9 @@ services:
       - cluster.name=docsitalia
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - cluster.routing.allocation.disk.watermark.flood_stage=99%
+      - cluster.routing.allocation.disk.watermark.high=99%
     ports:
       - 9200:9200
       - 9300:9300


### PR DESCRIPTION
to avoid error
```
flood stage disk watermark [95%] exceeded on ..., all indices on this node will be marked read-only
...
Config: Error 403 Forbidden: blocked by: [FORBIDDEN/12/index read-only / allow delete (api)]
```