### PR TITLE
Avoid double markdown registration errors

### DIFF
--- a/readthedocs/rtd_tests/tests/test_docsitalia.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia.py
@@ -783,7 +783,7 @@ class DocsItaliaTest(TestCase):
 
     def test_we_use_docsitalia_builder_conf_template(self):
         template = get_template('doc_builder/conf.py.tmpl')
-        self.assertIn('readthedocs/templates/doc_builder/conf.py.tmpl', template.origin.name)
+        self.assertIn('readthedocs/templates/docsitalia/overrides/doc_builder/conf.py.tmpl', template.origin.name)
 
     @pytest.mark.skipif(not IT_RESOLVER_IN_SETTINGS, reason='Require CLASS_OVERRIEDS in the settings file to work')
     @pytest.mark.itresolver

--- a/readthedocs/templates/docsitalia/overrides/doc_builder/conf.py.tmpl
+++ b/readthedocs/templates/docsitalia/overrides/doc_builder/conf.py.tmpl
@@ -38,11 +38,16 @@ else:
 
 # Support markdown
 def setup(app):
-    app.add_source_parser('.md', CommonMarkParser)
-    app.add_config_value('recommonmark_config', {
-            'enable_eval_rst': True
-        }, True)
-    app.add_transform(AutoStructify)
+    try:
+        if '.md' not in source_parsers:
+            app.add_source_parser('.md', CommonMarkParser)
+            app.add_config_value('recommonmark_config', {
+                    'enable_eval_rst': True
+                }, True)
+            app.add_transform(AutoStructify)
+    except Exception:
+        # md is already registered or not configured no further actions required
+        pass
 
 exclude_patterns = ['readme.md', 'README.md', 'license.md', 'LICENSE.md', 'authors.md', 'AUTHORS.md']
 


### PR DESCRIPTION
Move template under overrides directory to clarify our version wins over readthedocs.doc_builder.templates.doc_builder.conf.py.tmpl

Backport of #356 on `production` branch to make some documents build again

It depends on #396 to be merged