### PR TITLE
Fix eslint on production branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ install:
   - pip install tox-travis
   - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
   - source ~/.nvm/nvm.sh
-  - nvm install --lts
-  - nvm use --lts
+  - nvm install lts/carbon
+  - nvm use lts/carbon
   - npm install -g bower gulp@^3.x
   - npm install
   - bower install


### PR DESCRIPTION
È necessario pinnare la versione lts di npm perché è stata rilasciata la 12 nel frattempo, con cui rtd 2.3.13 non è compatibile