### PR TITLE
Proper analyzer configuration

### DIFF
--- a/readthedocs/docsitalia/settings/docker.py
+++ b/readthedocs/docsitalia/settings/docker.py
@@ -150,14 +150,6 @@ class DocsItaliaDockerSettings(CommunityBaseSettings):
         },
     }
 
-    @property
-    def ES_INDEXES(self):  # noqa - avoid pep8 N802
-        es_indexes = super().ES_INDEXES
-        for index_conf in es_indexes.values():
-            index_conf['analyzer'] = 'italian'
-
-        return es_indexes
-
     # RTD settings
     # This goes together with FILE_SYNCER setting
     # eg: FILE_SINCER = 'readthedocs.builds.syncers.*' (likely RemoteSyncer)

--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -138,15 +138,15 @@ class PageDocument(RTDDocTypeMixin, DocType):
     full_path = fields.KeywordField(attr='path')
 
     # Searchable content
-    title = fields.TextField(attr='processed_json.title')
+    title = fields.TextField(attr='processed_json.title', analyzer='italian')
     name = fields.KeywordField(attr='processed_json.title')
     date = fields.DateField(attr='modified_date')
     sections = fields.NestedField(
         attr='processed_json.sections',
         properties={
             'id': fields.KeywordField(),
-            'title': fields.TextField(),
-            'content': fields.TextField(),
+            'title': fields.TextField(analyzer='italian'),
+            'content': fields.TextField(analyzer='italian'),
         }
     )
     domains = fields.NestedField(


### PR DESCRIPTION
Fix #326 

We need to explicitly set a new analyzer as `default` to be able to define it at index level (https://www.elastic.co/guide/en/elasticsearch/reference/6.3/analysis.html#_specifying_a_search_time_analyzer)

The configured analyzer is the italian one (see https://www.elastic.co/guide/en/elasticsearch/reference/6.3/analysis-lang-analyzer.html#italian-analyzer) with `italian` stemmer instead of `light_italian` which does not cover singular / plural and other stemmings

The rationale for this approach is added as comment