### PR TITLE
Registration email text

### DIFF
--- a/readthedocs/locale/it/LC_MESSAGES/django.po
+++ b/readthedocs/locale/it/LC_MESSAGES/django.po
@@ -1704,10 +1704,10 @@ msgstr ""
 #: templates/account/email/email_confirmation_message.html:15
 #: templates/account/email/email_confirmation_message.txt:10
 msgid ""
-"If you did not sign up for an account with Read the Docs, you can disregard "
+"If you did not sign up for an account with Docs Italia, you can disregard "
 "this email."
 msgstr ""
-"Se non ti sei registrato per un account su Read the Docs, puoi non "
+"Se non ti sei registrato per un account su Docs Italia, puoi non "
 "considerare questa email."
 
 #: templates/account/email/email_confirmation_subject.txt:3


### PR DESCRIPTION
Fix #384 

Replace Read the docs text with proper "Docs italia" inside registration email