### PR TITLE
Add production / staging to list of travis allowed versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,10 @@ branches:
   - master
   - rel # Community release branch
   - relcorp # Corporate release branch
-  - /^dev/.*$/ # docsitalia dev branch
-  - /^production/.*$/ # docsitalia production branch
+  - /^dev.*$/ # docsitalia dev branch
+  - /^staging.*$/ # docsitalia staging branch
+  - /^production.*$/ # docsitalia production branch
   - /^italia-.*$/ # general docs italia branches
-  - /^feature/.*$/ # docsitalia feature branch
 
 addons:
   postgresql: "10"


### PR DESCRIPTION
Include proper regexp for environment branches

remove `feature` regexp which causes useless double builds for each PR