### PR TITLE
Bump django version to security release

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -3,7 +3,7 @@ pip==19.2.3
 appdirs==1.4.3
 virtualenv==16.7.5
 
-django==1.11.24  # pyup: <1.12
+django==1.11.27  # pyup: <1.12
 django-extensions==2.2.1
 django_polymorphic==2.1.2
 


### PR DESCRIPTION
See https://www.djangoproject.com/weblog/2019/dec/18/security-releases/

This will be ported to `italia-dev`