### PR TITLE
Allow to disable django-debug-toolbar indipendently from debug setting

### DIFF
--- a/.dockerenv
+++ b/.dockerenv
@@ -46,3 +46,4 @@ PYTHONDONTWRITEBYTECODE=1
 # this variable has TRAVIS prefix to be passed from tox to pytest without further tox.ini customization
 # to reduce the chance of a conflict
 TRAVIS_DOCSITALIA_DOCKER=1
+ENABLE_DEBUG_TOOLBAR=1

--- a/readthedocs/docsitalia/settings/docker.py
+++ b/readthedocs/docsitalia/settings/docker.py
@@ -263,7 +263,7 @@ class DocsItaliaDockerSettings(CommunityBaseSettings):
             index + 1,
             'restrictedsessions.middleware.RestrictedSessionsMiddleware'
         )
-        if os.environ.get('DEBUG', False):
+        if os.environ.get('DEBUG', False) and os.environ.get('ENABLE_DEBUG_TOOLBAR', True):
             middlewares.insert(0, 'debug_toolbar.middleware.DebugToolbarMiddleware')
         return middlewares
 


### PR DESCRIPTION
This is needed when ddt may conflict with some use-cases (testing 404/500 pages, for example)

Default behavior is not changed