### PR TITLE
#404 version facets default order

### DIFF
--- a/readthedocs/search/views.py
+++ b/readthedocs/search/views.py
@@ -193,6 +193,9 @@ def elastic_search(request, project_slug=None):
         log.debug('Search results: %s', results.to_dict())
         log.debug('Search facets: %s', results.facets.to_dict())
 
+    if facets and facets['version']:
+        facets['version'].sort()
+
     paginator = ESPaginator(results, page_size)
     page = paginator.page(page_int)
 

--- a/readthedocs/search/views.py
+++ b/readthedocs/search/views.py
@@ -193,7 +193,7 @@ def elastic_search(request, project_slug=None):
         log.debug('Search results: %s', results.to_dict())
         log.debug('Search facets: %s', results.facets.to_dict())
 
-    if facets and facets['version']:
+    if facets and 'version' in facets:
         facets['version'].sort()
 
     paginator = ESPaginator(results, page_size)


### PR DESCRIPTION
Version facet in search should be always ordered.

Fix #404