### PR TITLE
Tags where missing from documents after the upgrade

### DIFF
--- a/readthedocs/docsitalia/signals.py
+++ b/readthedocs/docsitalia/signals.py
@@ -72,8 +72,8 @@ def add_sphinx_context_data(sender, data, build_env, **kwargs):  # pylint: disab
     else:
         data['publisher'] = None
         data['publisher_logo'] = None
-    if build_env.project.tags:
-        data['tags'] = list(build_env.project.tags.names())
+    if build_env.project.tagged_items.exists():
+        data['tags'] = [t.tag.name for t in build_env.project.tagged_items.all()]
 
 
 @receiver(pre_delete, sender=PublisherProject)

--- a/readthedocs/rtd_tests/tests/test_docsitalia.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia.py
@@ -424,8 +424,8 @@ class DocsItaliaTest(TestCase):
             slug='myprojectslug',
             repo='https://github.com/testorg/myrepourl.git'
         )
-        project.tags.add('lorem', 'ipsum')
-        tags = project.tags.names()
+        project.tags.add('ipsum', 'lorem')
+        tags = sorted(project.tags.names())
         pub_project.projects.add(project)
         remote = RemoteRepository.objects.create(
             full_name='remote repo name',

--- a/readthedocs/rtd_tests/tests/test_docsitalia.py
+++ b/readthedocs/rtd_tests/tests/test_docsitalia.py
@@ -425,7 +425,7 @@ class DocsItaliaTest(TestCase):
             repo='https://github.com/testorg/myrepourl.git'
         )
         project.tags.add('lorem', 'ipsum')
-        tags = project.tags.names()
+        tags = sorted(project.tags.names())
         pub_project.projects.add(project)
         remote = RemoteRepository.objects.create(
             full_name='remote repo name',

--- a/readthedocs/search/views.py
+++ b/readthedocs/search/views.py
@@ -91,7 +91,7 @@ def elastic_search(request, project_slug=None):
         request_type = request.GET.get('type', 'file')
 
     user_input = UserInput(
-        query=request.GET.get('q'),
+        query=request.GET.get('q', '*'),
         type=request_type or request.GET.get('type', 'project'),
         project=project_slug or request.GET.get('project'),
         version=request.GET.get('version'),

--- a/readthedocs/templates/docsitalia/overrides/doc_builder/conf.py.tmpl
+++ b/readthedocs/templates/docsitalia/overrides/doc_builder/conf.py.tmpl
@@ -111,7 +111,7 @@ context = {
         ("{{ slug }}", "{{ url }}"),{% endfor %}
     ],
     'tags': [{% for tag in tags %}
-    (u"{{ tag }}", "/projects/tags/{{ tag|slugify }}/"),{% endfor %}
+    (u"{{ tag }}", "/search/?type=file&tags={{ tag|slugify }}"),{% endfor %}
     ],
     'slug': '{{ project.slug }}',
     'name': u'{{ project.name }}',

--- a/readthedocs/templates/docsitalia/overrides/search/elastic_search.html
+++ b/readthedocs/templates/docsitalia/overrides/search/elastic_search.html
@@ -3,7 +3,11 @@
 {% load core_tags docs_italia i18n static %}
 
 {% block title %}
-  {% blocktrans with query=query|default:"" %}Search: {{ query }}{% endblocktrans %}
+  {% if query != "*" %}
+    {% blocktrans with query=query|default:"" %}Ricerca: {{ query }}{% endblocktrans %}
+  {% else %}
+    {% blocktrans with query=query|default:"" %}Ricerca{% endblocktrans %}
+  {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -116,7 +120,7 @@
 
       <!-- Right content -->
       <div class="col-12 col-md-8">
-        <h1 class="main-title py-2 neutral-1-color">Risultati per: {{ query }}</h1>
+        <h1 class="main-title py-2 neutral-1-color">Risultati {% if query != "*" %}per: {{ query }}{% endif %}</h1>
 
         <div class="serp-results-info mt-5 pb-2">
           <p class="mb-0">


### PR DESCRIPTION
RTD 3 subtly changed the project class in the build environment, and as such, tags were no longer available. By using taggeditems we can recover the tag info

Also updated the URL linked to each tag

Fix #466