### PR TITLE
Redirect from tag search to normal search if additional input is added

### DIFF
--- a/readthedocs/docsitalia/views/core_views.py
+++ b/readthedocs/docsitalia/views/core_views.py
@@ -6,6 +6,7 @@ import logging
 from django.db.models import Case, When
 from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import render, redirect
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import DetailView, ListView, View
 
@@ -219,6 +220,9 @@ def server_error_401(request, template_name='401.html'):
 def search_by_tag(request, tag):
     """Wrapper around readthedocs.search.views.elastic_search to search by tag."""
     get_data = request.GET.copy()
+    if get_data.get('tags') or get_data.get('q') or get_data.get('type'):
+        real_search = '%s?%s' % (reverse('search'), request.GET.urlencode())
+        return HttpResponseRedirect(real_search)
     if not get_data.get('q'):
         get_data['q'] = '*'
     if not get_data.get('type'):

--- a/readthedocs/search/tests/test_docsitalia_search.py
+++ b/readthedocs/search/tests/test_docsitalia_search.py
@@ -247,11 +247,7 @@ class TestDocsItaliaPageSearch(object):
 
         # tags passed via GET are merged with the base one
         search_by_tag_url = reverse('search_by_tag', kwargs={'tag': custom_tag})
-        search_by_other_tag_results, _ = self._get_search_result(
-            url=search_by_tag_url,
-            client=client,
-            search_params={'tags': other_tag}
-        )
-        assert len(search_by_other_tag_results) == 4
-        for result in search_by_other_tag_results:
-            assert result.project == other_project.slug or result.project == project.slug
+        new_url = '%s?%s' % (reverse('search'), 'tags=other_tag')
+        resp = client.get(search_by_tag_url, {'tags': other_tag})
+        assert resp.status_code == 302
+        assert resp['Location'] == new_url


### PR DESCRIPTION
We just redirect user to the normal page id additional parameters are added. tag search view it's just a vanity shortcut anyway

Fix #484 